### PR TITLE
Edits mlops

### DIFF
--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -87,15 +87,15 @@ async function atlasRelativeLevel(cellIdentity, measuredFunctional) {
   const rowSum = cellIdentity.reduce((a, b) => a + b, 0);
   if (rowSum <= 0) return false;                                      // no reference
   const normalized = cellIdentity.map(v => v / rowSum);              // match training
+  const measuredNormalized = measuredFunctional / rowSum;
 
   const ArrayType = inputDtype === 'float64' ? Float64Array : Float32Array;
   const input = new ort.Tensor(inputDtype, ArrayType.from(normalized), [1, normalized.length]);
 
   const outputs = await session.run({ [session.inputNames[0]]: input });   // input name is 'X'
   const predictedNormalized = outputs[session.outputNames[0]].data[0];
-  const expected = predictedNormalized * rowSum;                     // back to raw scale
   const standard_deviation = ... ; 
-  return (measuredFunctional - expected) / standard_deviation;
+  return (measuredNormalized - predictedNormalized) / standard_deviation;
 }
 ```
 

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -28,19 +28,15 @@ curl "https://smprofiler.io/api/atlas-models/?study=LUAD%20progression"
 curl "https://smprofiler.io/api/atlas-models/?study=LUAD%20progression&target_channel=FOXP3"
 ```
 
-Each item is `AtlasModelMetadata`: `id`, `study`, `target_channel`, `input_channels`,
-`architecture_type`, `std_method`, `onnx_input_dtype`, metrics (`cv_r2`, `test_r2`,
-`test_mae`, `n_train`, `n_test`), `training_time_seconds`, `size_bytes`, `created`.
+Each item is [`AtlasModelMetadata`](/smprofiler/db/exchange_data_formats/atlas_models.py).
 
-Download the ONNX bytes for the latest model (or a specific `model_id`):
+Download the ONNX model itself for the latest model (or a specific `model_id`):
 
 ```sh
 curl -OJ "https://smprofiler.io/api/atlas-model/?study=LUAD%20progression&target_channel=FOXP3"
 ```
 
-The body is the ONNX model (`application/octet-stream`). Response headers describe how to
-run it: `X-Model-Id`, `X-Onnx-Input-Dtype`, `X-Input-Channels` (comma-separated, in input
-order), `X-Architecture-Type`, `X-Std-Method`.
+The body is the ONNX model file.
 
 ## Python
 

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -94,8 +94,8 @@ async function atlasRelativeLevel(cellIdentity, measuredFunctional) {
 
   const outputs = await session.run({ [session.inputNames[0]]: input });   // input name is 'X'
   const predictedNormalized = outputs[session.outputNames[0]].data[0];
-  const standard_deviation = ... ; 
-  return (measuredNormalized - predictedNormalized) / standard_deviation;
+  const standardDeviation = ... ; 
+  return (measuredNormalized - predictedNormalized) / standardDeviation;
 }
 ```
 

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -6,16 +6,16 @@ normal dataset. A cell is **atlas-relative positive** for that marker when its
 measured intensity exceeds the model's expectation.
 
 Models are small [ONNX](https://onnx.ai) regressors, one per `(study, target_channel)`, stored in the
-`atlas_model` database table (with metadata and versions). This page documents how to
+`atlas_model` database table with metadata and versions. This page documents how to
 **use** them; for how they are trained see [`smprofiler.atlas`](/smprofiler/atlas).
 
 Every model:
 - Takes in
     1. an input matrix of shape `(number_cells, number_identity_markers)`, with columns
-  in the order of the model's `input_channels`, and
+       in the order of the model's `input_channels`, and
     2. the functional marker column vector of size `number_cells`.
-- Expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
-  below do this for you).
+- Expects inputs (both identity and functional markers) normalized by the given cell's 
+  identity-marker row sum (the helpers below do this for you).
 - Returns the standard deviate of the functional marker values relative to expectation.
 
 ## API
@@ -27,15 +27,13 @@ curl "https://smprofiler.io/api/atlas-models/?study=LUAD%20progression"
 curl "https://smprofiler.io/api/atlas-models/?study=LUAD%20progression&target_channel=FOXP3"
 ```
 
-Each item is [`AtlasModelMetadata`](/smprofiler/db/exchange_data_formats/atlas_models.py).
+Each item is in format [`AtlasModelMetadata`](/smprofiler/db/exchange_data_formats/atlas_models.py).
 
 Download the ONNX model itself for the latest model (or a specific `model_id`):
 
 ```sh
 curl -OJ "https://smprofiler.io/api/atlas-model/?study=LUAD%20progression&target_channel=FOXP3"
 ```
-
-The body is the ONNX model file.
 
 ## Python
 

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -10,8 +10,10 @@ Models are small [ONNX](https://onnx.ai) regressors, one per `(study, target_cha
 **use** them; for how they are trained see [`smprofiler.atlas`](/smprofiler/atlas).
 
 Every model:
-- Takes (i) an input matrix of shape `(number_cells, number_identity_markers)`, with columns
-  in the order of the model's `input_channels`, and (ii) the functional marker column vector
+- Takes in
+    1. an input matrix of shape `(number_cells, number_identity_markers)`, with columns
+  in the order of the model's `input_channels`, and
+    2. the functional marker column vector.
   of size `number_cells`.
 - Expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
   below do this for you).

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -1,13 +1,13 @@
 # Atlas-reference models: usage
 
 Atlas-reference models predict the intensity a **functional** marker would have in a
-"normal" cell with a given **identity**-marker profile (trained on the Allen Institute
-Human Immune Health Atlas). A cell is **atlas-relative positive** for that marker when
-its measured intensity exceeds the model's expectation.
+"normal" cell with a given **identity**-marker profile, with respect to a reference
+normal dataset. A cell is **atlas-relative positive** for that marker when its
+measured intensity exceeds the model's expectation.
 
-Models are small ONNX regressors, one per `(study, target_channel)`, stored in the
+Models are small [ONNX](https://onnx.ai) regressors, one per `(study, target_channel)`, stored in the
 `atlas_model` database table (with metadata and versions). This page documents how to
-**use** them; for how they are trained see `smprofiler.atlas`.
+**use** them; for how they are trained see [`smprofiler.atlas`](/smprofiler/atlas).
 
 Every model:
 - takes one input tensor named `X`, shape `(n_cells, n_identity)`, columns in the order

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -10,13 +10,12 @@ Models are small [ONNX](https://onnx.ai) regressors, one per `(study, target_cha
 **use** them; for how they are trained see [`smprofiler.atlas`](/smprofiler/atlas).
 
 Every model:
-- takes one input tensor named `X`, shape `(n_cells, n_identity)`, columns in the order
-  of the model's `input_channels`;
-- expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
-  below do this for you);
-- returns the expected functional intensity on that same normalized scale;
-- uses input dtype `float32`, except Gaussian-Process models which use `float64` (given
-  by `onnx_input_dtype` in the metadata / the `X-Onnx-Input-Dtype` header).
+- Takes an input matrix of shape `(number_cells, number_identity_markers)`, with columns
+  in the order of the model's `input_channels`, and the functional marker column vector
+  of size `number_cells`.
+- Expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
+  below do this for you).
+- Returns the standard deviate of the functional marker values relative to expectation.
 
 ## API
 

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -72,15 +72,18 @@ import * as ort from 'onnxruntime-web';
 
 // 1. Fetch the model + the metadata needed to run it.
 const study = 'LUAD progression', channel = 'FOXP3';
+const metadata = await fetch(
+    `/api/atlas-models/?study=${encodeURIComponent(study)}&target_channel=${encodeURIComponent(channel)}`
+).json();
+const inputDtype = metadata.onnx_input_dtype;
+const inputChannels = metadata.input_channels;
 const response = await fetch(
   `/api/atlas-model/?study=${encodeURIComponent(study)}&target_channel=${encodeURIComponent(channel)}`
 );
-const inputDtype = response.headers.get('X-Onnx-Input-Dtype');        // 'float32' | 'float64'
-const inputChannels = response.headers.get('X-Input-Channels').split(',');
 const session = await ort.InferenceSession.create(new Uint8Array(await response.arrayBuffer()));
 
 // 2. Score one cell. `cellIdentity` is raw intensities in `inputChannels` order.
-async function atlasRelativePositive(cellIdentity, measuredFunctional) {
+async function atlasRelativeLevel(cellIdentity, measuredFunctional) {
   const rowSum = cellIdentity.reduce((a, b) => a + b, 0);
   if (rowSum <= 0) return false;                                      // no reference
   const normalized = cellIdentity.map(v => v / rowSum);              // match training
@@ -91,9 +94,10 @@ async function atlasRelativePositive(cellIdentity, measuredFunctional) {
   const outputs = await session.run({ [session.inputNames[0]]: input });   // input name is 'X'
   const predictedNormalized = outputs[session.outputNames[0]].data[0];
   const expected = predictedNormalized * rowSum;                     // back to raw scale
-  return measuredFunctional > expected;
+  const standard_deviation = ... ; 
+  return (measuredFunctional - expected) / standard_deviation;
 }
 ```
 
-For a whole slide, batch the cells into one `(n_cells, n_identity)` tensor rather than
+For a whole slide, batch the cells into one `(number_cells, number_identity_markers)` matrix rather than
 looping per cell.

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -10,8 +10,8 @@ Models are small [ONNX](https://onnx.ai) regressors, one per `(study, target_cha
 **use** them; for how they are trained see [`smprofiler.atlas`](/smprofiler/atlas).
 
 Every model:
-- Takes an input matrix of shape `(number_cells, number_identity_markers)`, with columns
-  in the order of the model's `input_channels`, and the functional marker column vector
+- Takes (i) an input matrix of shape `(number_cells, number_identity_markers)`, with columns
+  in the order of the model's `input_channels`, and (ii) the functional marker column vector
   of size `number_cells`.
 - Expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
   below do this for you).

--- a/docs/atlas_models.md
+++ b/docs/atlas_models.md
@@ -13,8 +13,7 @@ Every model:
 - Takes in
     1. an input matrix of shape `(number_cells, number_identity_markers)`, with columns
   in the order of the model's `input_channels`, and
-    2. the functional marker column vector.
-  of size `number_cells`.
+    2. the functional marker column vector of size `number_cells`.
 - Expects inputs **sum-normalized** by each cell's identity-marker row sum (the helpers
   below do this for you).
 - Returns the standard deviate of the functional marker values relative to expectation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ repository = "https://github.com/nadeemlab/smprofiler"
 [project.optional-dependencies]
 all = [
     "adiscstudies",
+    "anndata",
     "attrs",
     "bokeh",
     "boto3",
@@ -62,8 +63,11 @@ all = [
     "networkx",
     "numcodecs==0.15.1",
     "numpy",
+    "onnx",
+    "onnxruntime",
     "pandas",
     "psycopg",
+    "pyarrow",
     "pydantic",
     "PyJWT",
     "pymupdf",
@@ -74,6 +78,7 @@ all = [
     "setuptools>=82",
     "scipy",
     "scikit-learn",
+    "skl2onnx",
     "squidpy", "zarr",
     "sqlalchemy",
     "tables",

--- a/smprofiler/atlas/artifacts.py
+++ b/smprofiler/atlas/artifacts.py
@@ -49,10 +49,13 @@ def validate_onnx(
     sklearn_model,
     X_sample: NDArray,
     double_precision: bool = False,
-) -> bool:
+) -> tuple[bool, bool]:
     """
     Run the ONNX model and compare output to sklearn's predictions.
-    Returns True if outputs match within tolerance.
+
+    Returns two flags (tuple of booleans) indicating respectively
+    sufficient concordance between the ordinary predictions, and between 
+    the predicted standard deviations.
     """
     options = SessionOptions()
     ERROR_LEVEL = 3
@@ -65,20 +68,17 @@ def validate_onnx(
     a2 = sklearn_mean.flatten()
     difference = np.sum(np.abs(a1 - a2)) / np_norm(a2)
     cutoff = 2e-2
-    if difference > cutoff:
-        print([onnx_mean, sklearn_mean])
-        print(np.abs(a1 - a2))
+    ordinary_prediction_concordance = difference < cutoff
+    if not ordinary_prediction_concordance:
         logger.error('ONNX validation, vs. sklearn: difference norm ratio = %.6f (tolerated up to %E)', difference, cutoff)
-        return False
     a1 = onnx_std.flatten()
     a2 = sklearn_std.flatten()
     difference = np.sum(np.abs(a1 - a2)) / np_norm(a2)
-    if difference > 0.1:
-        print([onnx_std, sklearn_std])
-        print(np.abs(a1 - a2))
+    std_concordance = difference < 0.1
+    if not std_concordance:
         logger.warning('ONNX validation, vs sklearn: standard deviation prediction difference: %.6f', difference)
     logger.info('ONNX validation passed (max abs diff = %.2e)', difference)
-    return True
+    return (ordinary_prediction_concordance, std_concordance)
 
 
 def write_metadata_to_file(

--- a/smprofiler/atlas/artifacts.py
+++ b/smprofiler/atlas/artifacts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import cast
 
 import numpy as np
+from numpy.linalg import norm as np_norm
 from numpy.typing import NDArray
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.linear_model import BayesianRidge
@@ -58,13 +59,25 @@ def validate_onnx(
     options.log_severity_level = ERROR_LEVEL
     session = InferenceSession(str(onnx_path), sess_options=options)
     dtype = np.float64 if double_precision else np.float32
-    onnx_prediction = cast(NDArray, session.run(None, {'X': X_sample.astype(dtype)}))[0].flatten()
-    sklearn_prediction = sklearn_model.predict(X_sample)
-    max_diff = np.abs(onnx_prediction - sklearn_prediction).max()
-    if max_diff > 1e-3:
-        logger.warning('ONNX validation: max abs diff = %.6f (tolerated up to 1e-3)', max_diff)
+    onnx_mean, onnx_std = cast(tuple[NDArray, NDArray], session.run(None, {'X': X_sample.astype(dtype)}))
+    sklearn_mean, sklearn_std = cast(tuple[NDArray, NDArray], sklearn_model.predict(X_sample, return_std=True))
+    a1 = onnx_mean.flatten()
+    a2 = sklearn_mean.flatten()
+    difference = np.sum(np.abs(a1 - a2)) / np_norm(a2)
+    cutoff = 2e-2
+    if difference > cutoff:
+        print([onnx_mean, sklearn_mean])
+        print(np.abs(a1 - a2))
+        logger.error('ONNX validation, vs. sklearn: difference norm ratio = %.6f (tolerated up to %E)', difference, cutoff)
         return False
-    logger.info('ONNX validation passed (max abs diff = %.2e)', max_diff)
+    a1 = onnx_std.flatten()
+    a2 = sklearn_std.flatten()
+    difference = np.sum(np.abs(a1 - a2)) / np_norm(a2)
+    if difference > 0.1:
+        print([onnx_std, sklearn_std])
+        print(np.abs(a1 - a2))
+        logger.warning('ONNX validation, vs sklearn: standard deviation prediction difference: %.6f', difference)
+    logger.info('ONNX validation passed (max abs diff = %.2e)', difference)
     return True
 
 

--- a/smprofiler/atlas/artifacts.py
+++ b/smprofiler/atlas/artifacts.py
@@ -10,8 +10,8 @@ from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
-from sklearn import GaussianProcessRegressor
-from sklearn import BayesianRidge
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.linear_model import BayesianRidge
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import DoubleTensorType
 from skl2onnx.common.data_types import FloatTensorType

--- a/smprofiler/atlas/artifacts.py
+++ b/smprofiler/atlas/artifacts.py
@@ -2,21 +2,20 @@
 
 Converts a fitted estimator to ONNX (via skl2onnx), verifies the exported model
 reproduces the sklearn predictions within tolerance, and writes the per-model
-JSON metadata sidecar.
-
-Gaussian Process predictions involve kernel-matrix inversion and only reproduce
-in double precision (float32 is off by a few percent), so GP models are exported
-and run with float64 inputs; the others use float32. Callers pass
-``double_precision`` and record the choice in the metadata (``onnx_input_dtype``)
-so inference feeds the matching dtype.
+JSON metadata.
 """
 import json
 from pathlib import Path
+from typing import cast
 
 import numpy as np
+from numpy.typing import NDArray
 from skl2onnx import convert_sklearn
-from skl2onnx.common.data_types import DoubleTensorType, FloatTensorType
-from onnxruntime import InferenceSession, SessionOptions
+from skl2onnx.common.data_types import DoubleTensorType
+from skl2onnx.common.data_types import FloatTensorType
+from onnxruntime import InferenceSession
+from onnxruntime import SessionOptions  # type: ignore  # conditionally imported due to c binding under the hood
+from onnx import ModelProto
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 
@@ -25,46 +24,47 @@ logger = colorized_logger(__name__)
 
 def export_to_onnx(
     model,
-    n_features: int,
+    number_features: int,
     output_path: Path,
     double_precision: bool = False,
 ) -> None:
     """Convert a fitted sklearn estimator / pipeline to ONNX and save."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tensor_type = DoubleTensorType if double_precision else FloatTensorType
-    initial_type = [("X", tensor_type([None, n_features]))]
-    onnx_model = convert_sklearn(model, initial_types=initial_type)
-    with open(output_path, "wb") as f:
+    initial_type = [('X', tensor_type([None, number_features]))]
+    onnx_model = cast(ModelProto, convert_sklearn(model, initial_types=initial_type))
+    with open(output_path, 'wb') as f:
         f.write(onnx_model.SerializeToString())
     size_kb = output_path.stat().st_size / 1024
-    logger.info("ONNX model saved: %s (%.1f KB)", output_path, size_kb)
+    logger.info('ONNX model saved: %s (%.1f KB)', output_path, size_kb)
 
 
 def validate_onnx(
     onnx_path: Path,
     sklearn_model,
-    X_sample: np.ndarray,
+    X_sample: NDArray,
     double_precision: bool = False,
 ) -> bool:
     """
     Run the ONNX model and compare output to sklearn's predictions.
     Returns True if outputs match within tolerance.
     """
-    ort_opts = SessionOptions()
-    ort_opts.log_severity_level = 3  # 0=VERBOSE … 3=ERROR (onnxruntime's own C-level control)
-    sess = InferenceSession(str(onnx_path), sess_options=ort_opts)
+    options = SessionOptions()
+    ERROR_LEVEL = 3
+    options.log_severity_level = ERROR_LEVEL
+    session = InferenceSession(str(onnx_path), sess_options=options)
     dtype = np.float64 if double_precision else np.float32
-    onnx_pred = sess.run(None, {"X": X_sample.astype(dtype)})[0].flatten()
-    sklearn_pred = sklearn_model.predict(X_sample)
-    max_diff = np.abs(onnx_pred - sklearn_pred).max()
+    onnx_prediction = cast(NDArray, session.run(None, {'X': X_sample.astype(dtype)}))[0].flatten()
+    sklearn_prediction = sklearn_model.predict(X_sample)
+    max_diff = np.abs(onnx_prediction - sklearn_prediction).max()
     if max_diff > 1e-3:
-        logger.warning("ONNX validation: max abs diff = %.6f (tolerated up to 1e-3)", max_diff)
+        logger.warning('ONNX validation: max abs diff = %.6f (tolerated up to 1e-3)', max_diff)
         return False
-    logger.info("ONNX validation passed (max abs diff = %.2e)", max_diff)
+    logger.info('ONNX validation passed (max abs diff = %.2e)', max_diff)
     return True
 
 
-def write_metadata(
+def write_metadata_to_file(
     output_path: Path,
     study: str,
     target_channel: str,
@@ -78,28 +78,29 @@ def write_metadata(
     n_test: int,
     atlas_version: str,
     sum_normalized: bool = True,
-    std_method: str = "global_residual_std",
-    global_std: float = float("nan"),
-    onnx_input_dtype: str = "float32",
+    std_method: str = 'global_residual_std',
+    global_std: float = float('nan'),
+    onnx_input_dtype: str = 'float32',
 ) -> None:
     meta = {
-        "study": study,
-        "target_channel": target_channel,
-        "input_channels": input_channels,
-        "model_type": model_type,
-        "cv_r2": round(cv_r2, 6),
-        "cv_r2_std": round(cv_r2_std, 6),
-        "test_r2": round(test_r2, 6),
-        "test_mae": round(test_mae, 6),
-        "n_train": n_train,
-        "n_test": n_test,
-        "atlas_version": atlas_version,
-        "sum_normalized": sum_normalized,
-        "std_method": std_method,
-        "global_std": round(float(global_std), 8) if not np.isnan(global_std) else None,
-        "onnx_input_dtype": onnx_input_dtype,
+        'study': study,
+        'target_channel': target_channel,
+        'input_channels': input_channels,
+        'model_type': model_type,
+        'cv_r2': round(cv_r2, 6),
+        'cv_r2_std': round(cv_r2_std, 6),
+        'test_r2': round(test_r2, 6),
+        'test_mae': round(test_mae, 6),
+        'n_train': n_train,
+        'n_test': n_test,
+        'atlas_version': atlas_version,
+        'sum_normalized': sum_normalized,
+        'std_method': std_method,
+        'global_std': round(float(global_std), 8) if not np.isnan(global_std) else None,
+        'onnx_input_dtype': onnx_input_dtype,
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with open(output_path, 'w') as f:
         json.dump(meta, f, indent=2)
-    logger.info("Metadata saved: %s", output_path)
+    logger.info('Metadata saved: %s', output_path)
+

--- a/smprofiler/atlas/artifacts.py
+++ b/smprofiler/atlas/artifacts.py
@@ -10,6 +10,8 @@ from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
+from sklearn import GaussianProcessRegressor
+from sklearn import BayesianRidge
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import DoubleTensorType
 from skl2onnx.common.data_types import FloatTensorType
@@ -32,7 +34,9 @@ def export_to_onnx(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tensor_type = DoubleTensorType if double_precision else FloatTensorType
     initial_type = [('X', tensor_type([None, number_features]))]
-    onnx_model = cast(ModelProto, convert_sklearn(model, initial_types=initial_type))
+    # For the below, see: https://onnx.ai/sklearn-onnx/auto_examples/plot_gpr.html#return-std-true
+    options = {BayesianRidge: {'return_std': True}, GaussianProcessRegressor: {'return_std': True}}
+    onnx_model = cast(ModelProto, convert_sklearn(model, initial_types=initial_type, options=options))
     with open(output_path, 'wb') as f:
         f.write(onnx_model.SerializeToString())
     size_kb = output_path.stat().st_size / 1024

--- a/smprofiler/atlas/atlas_data.py
+++ b/smprofiler/atlas/atlas_data.py
@@ -61,10 +61,9 @@ def report_parquet_attributes(path: Path, smprofiler_to_atlas: dict[str, str]) -
 def load_atlas_subset(
     parquet_path: Path,
     atlas_columns: list[str],
-    spt_names: list[str],
     max_cells: int | None = None,
     rng: np.random.Generator | None = None,
-) -> tuple[np.ndarray, list[str]]:
+) -> np.ndarray:
     """
     Load specific gene columns from the atlas Parquet table into memory.
 
@@ -73,12 +72,11 @@ def load_atlas_subset(
         atlas_columns: atlas gene names to load (may contain duplicates when
             several SPT channels share one atlas gene; each entry becomes its
             own output column)
-        spt_names: corresponding SPT channel names (same length as atlas_columns)
         max_cells: if set, randomly sample this many cells
         rng: random number generator for sampling
 
     Returns:
-        (X, spt_names) where X has shape (n_cells, len(atlas_columns)).
+        X where X has shape (n_cells, len(atlas_columns)).
     """
     logger.info("Loading %d atlas columns from parquet: %s", len(atlas_columns), atlas_columns)
     t0 = time.monotonic()
@@ -114,4 +112,5 @@ def load_atlas_subset(
         X.shape,
         X.nbytes / 1024 ** 2,
     )
-    return X, spt_names
+    return X
+

--- a/smprofiler/atlas/atlas_data.py
+++ b/smprofiler/atlas/atlas_data.py
@@ -2,103 +2,81 @@
 
 Reads the two files produced by the atlas aggregation step (in smprofiler-data):
 
-- ``cell_atlas_small.parquet`` — a cell × gene expression table restricted to
-  the atlas genes relevant to SPT channels.
-- ``smprofiler_channels_to_atlas.tsv`` — the manual mapping from SPT channel
-  names to atlas gene (column) names.
-
-The aggregation step subselects and joins the per-cell-type atlas downloads and
-applies the manually curated ``channel_proxies.json``; this module simply
-consumes its Parquet/TSV output. (The heuristic fallback mapping lives in
-:mod:`smprofiler.atlas.automatic_channel_mapping`.)
+- ``cell_atlas_small.parquet`` - a cell × gene expression table restricted to
+  the atlas genes relevant to SMProfiler channels.
+- ``smprofiler_channels_to_atlas.tsv`` - the manual mapping from SMProfiler channel
+  names to atlas gene names.
 """
 import time
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
+from numpy.typing import NDArray
+from pandas import read_csv
 import pyarrow.parquet as pq
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 from smprofiler.atlas.reporting import format_elapsed
-from smprofiler.atlas.channel_annotations import normalize_name
 
 logger = colorized_logger(__name__)
 
 
 def load_channel_mapping(mapping_path: Path) -> dict[str, str]:
     """
-    Load the manual SMProfiler-channel → atlas-gene mapping.
+    The manual SMProfiler-channel to atlas-gene mapping.
 
     The source TSV has columns ``SMProfiler channel name`` and ``Atlas gene name``.
     Several SMProfiler channels may map to the same atlas gene (e.g. CD45, CD45RA and
     CD45RO all map to PTPRC), so the returned dict is many-to-one.
 
     Returns:
-        dict mapping smprofiler_channel_name → atlas_gene_name.
+        dict mapping smprofiler_channel_name to atlas_gene_name.
     """
-    df = pd.read_csv(mapping_path, sep="\t")
+    df = read_csv(mapping_path, sep='\t')
     columns = ('SMProfiler channel name', 'Atlas gene name')
     if tuple(df.columns) != columns:
         raise ValueError(f'Wrong columns: {columns}')
     return dict(df.itertuples(index=False))
 
-def report_parquet_attributes(path: Path, smprofiler_to_atlas: dict[str, str]) -> None:
-    size_mb = path.stat().st_size / 1024 ** 2
-    schema = pq.read_schema(path)
-    names = list(schema.names)
-    n_rows = pq.ParquetFile(path).metadata.num_rows
-    logger.info(
-        "Atlas parquet (%.1f MB): %s cells × %d genes — %s",
-        size_mb, f"{n_rows:,}", len(names), path,
-    )
-    missing = set(smprofiler_to_atlas.values()).difference(names)
-    if len(missing) > 0:
-        logger.error('Atlas does not actually contain: %s', missing)
-    else:
-        logger.info('All manually-mapped-to atlas gene names are actually in atlas.')
- 
 def load_atlas_subset(
     parquet_path: Path,
     atlas_columns: list[str],
     max_cells: int | None = None,
     rng: np.random.Generator | None = None,
-) -> np.ndarray:
+) -> NDArray:
     """
-    Load specific gene columns from the atlas Parquet table into memory.
+    Load specific gene columns from the atlas Parquet table.
 
     Args:
         parquet_path: path to cell_atlas_small.parquet
         atlas_columns: atlas gene names to load (may contain duplicates when
-            several SPT channels share one atlas gene; each entry becomes its
-            own output column)
+            several SMProfiler channels share one atlas gene; each entry
+            becomes its own output column)
         max_cells: if set, randomly sample this many cells
         rng: random number generator for sampling
 
     Returns:
-        X where X has shape (n_cells, len(atlas_columns)).
+        numpy.NDArray of shape (n_cells, len(atlas_columns)).
     """
-    logger.info("Loading %d atlas columns from parquet: %s", len(atlas_columns), atlas_columns)
+    logger.info('Loading %d atlas columns from parquet: %s', len(atlas_columns), atlas_columns)
     t0 = time.monotonic()
 
-    # Read each distinct gene column once; duplicate SPT→gene entries are
-    # expanded back out when assembling X below.
-    unique_columns = list(dict.fromkeys(atlas_columns))
+    unique_columns = list(set(atlas_columns))
     parquet_file = pq.ParquetFile(parquet_path)
-    n_total = parquet_file.metadata.num_rows
+    number_cells = parquet_file.metadata.num_rows
     table = parquet_file.read(columns=unique_columns)
 
-    if max_cells and n_total > max_cells:
+    if max_cells and number_cells > max_cells:
         if rng is None:
             rng = np.random.default_rng(42)
-        idx = np.sort(rng.choice(n_total, size=max_cells, replace=False))
-        table = table.take(idx)
+        indices = np.sort(rng.choice(number_cells, size=max_cells, replace=False))
+        table = table.take(indices)
         logger.info(
-            "Sampling %s / %s cells from atlas (%.1f%%)…",
-            f"{max_cells:,}", f"{n_total:,}", 100 * max_cells / n_total,
+            'Sampling %s / %s cells from atlas (%.1f%%)…',
+            f'{max_cells:,}', f'{number_cells:,}', 100 * max_cells / number_cells,
         )
     else:
-        logger.info("Loading all %s cells from atlas…", f"{n_total:,}")
+        logger.info('Loading all %s cells from atlas…', f'{number_cells:,}')
 
     column_values = {
         name: table.column(name).to_numpy(zero_copy_only=False).astype(np.float32)
@@ -107,10 +85,25 @@ def load_atlas_subset(
     X = np.column_stack([column_values[name] for name in atlas_columns]).astype(np.float32)
 
     logger.info(
-        "Atlas data loaded in %s — shape %s (%.1f MB)",
+        'Atlas data loaded in %s — shape %s (%.1f MB)',
         format_elapsed(time.monotonic() - t0),
         X.shape,
-        X.nbytes / 1024 ** 2,
+        X.nbytes / (1024 ** 2),
     )
     return X
 
+def report_parquet_attributes(path: Path, smprofiler_to_atlas: dict[str, str]) -> None:
+    size_mb = path.stat().st_size / (1024 ** 2)
+    schema = pq.read_schema(path)
+    names = list(schema.names)
+    n_rows = pq.ParquetFile(path).metadata.num_rows
+    logger.info(
+        'Atlas parquet (%.1f MB): %s cells × %d genes — %s',
+        size_mb, f'{n_rows:,}', len(names), path,
+    )
+    missing = set(smprofiler_to_atlas.values()).difference(names)
+    if len(missing) > 0:
+        logger.error('Atlas does not actually contain: %s', missing)
+    else:
+        logger.info('All manually-mapped-to atlas gene names are actually in atlas.')
+ 

--- a/smprofiler/atlas/atlas_data.py
+++ b/smprofiler/atlas/atlas_data.py
@@ -21,57 +21,43 @@ import pyarrow.parquet as pq
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 from smprofiler.atlas.reporting import format_elapsed
+from smprofiler.atlas.channel_annotations import normalize_name
 
 logger = colorized_logger(__name__)
-
-# Column headers in smprofiler_channels_to_atlas.tsv
-_SPT_COLUMN = "SMProfiler channel name"
-_ATLAS_COLUMN = "Atlas gene name"
 
 
 def load_channel_mapping(mapping_path: Path) -> dict[str, str]:
     """
-    Load the manual SPT-channel → atlas-gene mapping from the aggregation TSV.
+    Load the manual SMProfiler-channel → atlas-gene mapping.
 
-    The TSV has columns ``"SMProfiler channel name"`` and ``"Atlas gene name"``.
-    Several SPT channels may map to the same atlas gene (e.g. CD45, CD45RA and
+    The source TSV has columns ``SMProfiler channel name`` and ``Atlas gene name``.
+    Several SMProfiler channels may map to the same atlas gene (e.g. CD45, CD45RA and
     CD45RO all map to PTPRC), so the returned dict is many-to-one.
 
     Returns:
-        dict mapping spt_channel_name → atlas_gene_name.
+        dict mapping smprofiler_channel_name → atlas_gene_name.
     """
     df = pd.read_csv(mapping_path, sep="\t")
-    missing = {_SPT_COLUMN, _ATLAS_COLUMN} - set(df.columns)
-    if missing:
-        raise ValueError(
-            f"Channel mapping {mapping_path} is missing column(s) {sorted(missing)}; "
-            f"found {list(df.columns)}"
-        )
-    spt_to_atlas = {
-        str(spt).strip(): str(atlas).strip()
-        for spt, atlas in zip(df[_SPT_COLUMN], df[_ATLAS_COLUMN])
-        if pd.notna(spt) and pd.notna(atlas)
-    }
-    logger.info(
-        "Channel mapping: %d SPT channels → %d atlas genes (from %s)",
-        len(spt_to_atlas), len(set(spt_to_atlas.values())), mapping_path,
-    )
-    return spt_to_atlas
+    columns = ('SMProfiler channel name', 'Atlas gene name')
+    if tuple(df.columns) != columns:
+        raise ValueError(f'Wrong columns: {columns}')
+    return dict(df.itertuples(index=False))
 
-
-def load_atlas_gene_names(parquet_path: Path) -> list[str]:
-    """Return the gene (column) names of the atlas Parquet table, without loading data."""
-    size_mb = parquet_path.stat().st_size / 1024 ** 2
-    schema = pq.read_schema(parquet_path)
+def report_parquet_attributes(path: Path, smprofiler_to_atlas: dict[str, str]) -> None:
+    size_mb = path.stat().st_size / 1024 ** 2
+    schema = pq.read_schema(path)
     names = list(schema.names)
-    n_rows = pq.ParquetFile(parquet_path).metadata.num_rows
+    n_rows = pq.ParquetFile(path).metadata.num_rows
     logger.info(
         "Atlas parquet (%.1f MB): %s cells × %d genes — %s",
-        size_mb, f"{n_rows:,}", len(names), parquet_path,
+        size_mb, f"{n_rows:,}", len(names), path,
     )
-    return names
-
-
+    missing = set(smprofiler_to_atlas.values()).difference(names)
+    if len(missing) > 0:
+        logger.error('Atlas does not actually contain: %s', missing)
+    else:
+        logger.info('All manually-mapped-to atlas gene names are actually in atlas.')
+ 
 def load_atlas_subset(
     parquet_path: Path,
     atlas_columns: list[str],

--- a/smprofiler/atlas/cache.py
+++ b/smprofiler/atlas/cache.py
@@ -1,0 +1,30 @@
+"""
+Lightweight HTTP response cache, for convenience.
+"""
+from sqlite3 import Connection
+
+
+class StandaloneSQLiteHTTPCache:
+    cache_filename = '.temporary_http_response_cache.sqlite.db'
+
+    @classmethod
+    def cache_response(cls, url: str, response: bytes) -> None:
+        """
+        Overwrites value with key ``url`` if it exists.
+        """
+        with Connection(cls.cache_filename) as connection:
+            cursor = connection.cursor()
+            cursor.execute('CREATE TABLE IF NOT EXISTS cache(url VARCHAR, response BYTES)')
+            cursor.execute('INSERT INTO cache VALUES (?, ?);', (url, response))
+
+    @classmethod
+    def retrieve_response(cls, url: str) -> bytes | None:
+        with Connection(cls.cache_filename) as connection:
+            cursor = connection.cursor()
+            cursor.execute('SELECT response FROM cache WHERE url=?', (url,))
+            rows = tuple(cursor.fetchall())
+        if len(rows) == 0:
+            return None
+        return rows[0][0]
+
+

--- a/smprofiler/atlas/channel_annotations.py
+++ b/smprofiler/atlas/channel_annotations.py
@@ -9,7 +9,8 @@ be the canonical source for this information. Loading from the local pre-API
 source files is deprecated, to ensure this information is always formatted in
 just one way.
 
-When loading from files, the files should be the JSONs as provided by the API.
+When loading from files, the files should be the JSONs as provided by the API
+server.
 """
 import json
 import urllib.request
@@ -21,64 +22,65 @@ from smprofiler.standalone_utilities.log_formats import colorized_logger
 logger = colorized_logger(__name__)
 
 def load_channel_annotations_from_files(
-    annotations_path: Path | StringIO,
-    aliases_path: Path | StringIO,
-) -> tuple[set, dict]:
+    annotations: Path | StringIO,
+    aliases: Path | StringIO,
+) -> tuple[set, dict[str, str]]:
     """
-    Parse /channel-annotations/ and /channel-aliases/ .
+    Parse ``/channel-annotations/`` and ``/channel-aliases/`` responses.
 
     Returns:
         identity_channels: set of canonical identity channel names
         aliases: dict mapping alias → canonical name
     """
-    if isinstance(aliases_path, StringIO):
-        aliases = json.load(aliases_path)
+    if isinstance(aliases, StringIO):
+        aliases_data = json.load(aliases)['aliases']
     else:
-        with open(aliases_path) as f:
-            aliases = json.load(f)['aliases']
+        with open(aliases) as f:
+            aliases_data = json.load(f)['aliases']
 
-    if isinstance(annotations_path, StringIO):
-        data = json.load(annotations_path)
+    if isinstance(annotations, StringIO):
+        data = json.load(annotations)
     else:
-        with open(annotations_path) as f:
+        with open(annotations) as f:
             data = json.load(f)
 
     groups = data['channelGroups']
     identity_channels: set = set(groups['identity']['channels'])
     logger.info(
         'Channel annotations: %d identity, %d aliases',
-        len(identity_channels), len(aliases),
+        len(identity_channels), len(aliases_data),
     )
-    return identity_channels, aliases
+    return identity_channels, aliases_data
 
 
 def load_channel_annotations_from_api(
     base_url: str,
     timeout: int = 30,
-) -> tuple[set, dict]:
+    ) -> tuple[set, dict[str, str]]:
     """
-    Fetch channel annotations from the smprofiler API,
-    ``/channel-annotations/`` and ``/channel-aliases/``.
+    Fetch channel annotations from the smprofiler API, ``/channel-annotations/``
+    and ``/channel-aliases/``.
 
-    Returns the same as load_channel_annotations_from_file().
+    Returns the same as load_channel_annotations_from_file.
     """
     base = base_url.rstrip('/')
-
-    def _get_and_fill_buffer(url: str) -> StringIO:
-        f = StringIO()
-        request = urllib.request.Request(url, headers={'Accept': 'application/json'})
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            f.write(response.read().decode())
-        return f
 
     annotations_url = f'{base}/channel-annotations/'
     aliases_url = f'{base}/channel-aliases/'
 
     logger.info('Fetching channel annotations from API: %s', annotations_url)
-    annotations_file = _get_and_fill_buffer(annotations_url)
+    annotations_file = _get_and_fill_buffer(annotations_url, timeout)
     logger.info('Fetching channel aliases from API: %s', aliases_url)
-    aliases_file = _get_and_fill_buffer(aliases_url)
+    aliases_file = _get_and_fill_buffer(aliases_url, timeout)
     return load_channel_annotations_from_files(annotations_file, aliases_file)
+
+def _get_and_fill_buffer(url: str, timeout: int) -> StringIO:
+    f = StringIO()
+    request = urllib.request.Request(url, headers={'Accept': 'application/json'})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        f.write(response.read().decode())
+    f.seek(0)
+    return f
 
 
 def normalize_name(name: str, aliases: dict) -> str:

--- a/smprofiler/atlas/channel_annotations.py
+++ b/smprofiler/atlas/channel_annotations.py
@@ -1,123 +1,87 @@
-"""Channel annotation loading and alias normalization.
+"""Channel annotation loading and alias normalization for atlas reference purposes.
 
 Provides the identity/functional channel classification and alias resolution
-used to reconcile marker names between SPT studies and the atlas. The smprofiler
-API (:func:`load_channel_annotations_from_api`) is the source of truth; loading
-from a local JSON file (:func:`load_channel_annotations`) is deprecated, so that
-training never runs against annotations that are stale relative to the live
-service. HGNC-symbol normalization lives in
-:mod:`smprofiler.atlas.hgnc_normalization`.
+used to reconcile marker names between SMProfiler studies and the atlas. This
+is essentially manually maintained.
+
+The smprofiler API (:func:`load_channel_annotations_from_api`) is intended to
+be the canonical source for this information. Loading from the local pre-API
+source files is deprecated, to ensure this information is always formatted in
+just one way.
+
+When loading from files, the files should be the JSONs as provided by the API.
 """
 import json
 import urllib.request
-import warnings
 from pathlib import Path
+from io import StringIO
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 
 logger = colorized_logger(__name__)
 
-
-def load_channel_annotations(annotations_path: Path) -> tuple[set, set, dict]:
+def load_channel_annotations_from_files(
+    annotations_path: Path | StringIO,
+    aliases_path: Path | StringIO,
+) -> tuple[set, dict]:
     """
-    Parse channel_annotations.json.
-
-    .. deprecated::
-        Load channel annotations from the smprofiler API via
-        :func:`load_channel_annotations_from_api` instead. A local file can be
-        stale relative to the live service, causing training to run against
-        annotations that no longer match production.
+    Parse /channel-annotations/ and /channel-aliases/ .
 
     Returns:
         identity_channels: set of canonical identity channel names
-        functional_channels: set of canonical functional channel names
-        aliases: dict mapping alias → canonical name (for channels only)
+        aliases: dict mapping alias → canonical name
     """
-    warnings.warn(
-        "load_channel_annotations (local file) is deprecated; load channel "
-        "annotations from the smprofiler API via load_channel_annotations_from_api.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    with open(annotations_path) as f:
-        data = json.load(f)
+    if isinstance(aliases_path, StringIO):
+        aliases = json.load(aliases_path)
+    else:
+        with open(aliases_path) as f:
+            aliases = json.load(f)['aliases']
 
-    groups = data["groups"]
-    identity_channels: set = set(groups["identity"]["channels"])
+    if isinstance(annotations_path, StringIO):
+        data = json.load(annotations_path)
+    else:
+        with open(annotations_path) as f:
+            data = json.load(f)
 
-    functional_channels: set = set()
-    for group_name, group_data in groups.items():
-        if group_name != "identity":
-            functional_channels.update(group_data["channels"])
-
-    all_channels = identity_channels | functional_channels
-
-    # Filter aliases to channel aliases only (aliases also contains cell type strings)
-    aliases = {}
-    for alias, canonical in data.get("aliases", {}).items():
-        if isinstance(canonical, str) and canonical in all_channels:
-            aliases[alias] = canonical
-
+    groups = data['channelGroups']
+    identity_channels: set = set(groups['identity']['channels'])
     logger.info(
-        "Channel annotations: %d identity, %d functional, %d aliases",
-        len(identity_channels), len(functional_channels), len(aliases),
+        'Channel annotations: %d identity, %d aliases',
+        len(identity_channels), len(aliases),
     )
-    return identity_channels, functional_channels, aliases
+    return identity_channels, aliases
 
 
 def load_channel_annotations_from_api(
     base_url: str,
     timeout: int = 30,
-) -> tuple[set, set, dict]:
+) -> tuple[set, dict]:
     """
-    Fetch channel annotations from the smprofiler API.
+    Fetch channel annotations from the smprofiler API,
+    ``/channel-annotations/`` and ``/channel-aliases/``.
 
-    Calls:
-        GET {base_url}/channel-annotations/
-        GET {base_url}/channel-aliases/
-
-    Returns the same (identity_channels, functional_channels, aliases) tuple
-    as load_channel_annotations().
+    Returns the same as load_channel_annotations_from_file().
     """
-    base = base_url.rstrip("/")
+    base = base_url.rstrip('/')
 
-    def _get_json(url: str) -> dict:
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
+    def _get_and_fill_buffer(url: str) -> StringIO:
+        f = StringIO()
+        request = urllib.request.Request(url, headers={'Accept': 'application/json'})
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            f.write(response.read().decode())
+        return f
 
-    annotations_url = f"{base}/channel-annotations/"
-    aliases_url = f"{base}/channel-aliases/"
+    annotations_url = f'{base}/channel-annotations/'
+    aliases_url = f'{base}/channel-aliases/'
 
-    logger.info("Fetching channel annotations from API: %s", annotations_url)
-    ann_data = _get_json(annotations_url)
-    logger.info("Fetching channel aliases from API: %s", aliases_url)
-    ali_data = _get_json(aliases_url)
-
-    channel_groups: dict = ann_data.get("channelGroups", {})
-    identity_channels: set = set(channel_groups.get("identity", {}).get("channels", []))
-
-    functional_channels: set = set()
-    for group_name, group_data in channel_groups.items():
-        if group_name != "identity":
-            functional_channels.update(group_data.get("channels", []))
-
-    all_channels = identity_channels | functional_channels
-
-    raw_aliases: dict = ali_data.get("aliases", {})
-    aliases = {
-        alias: canonical
-        for alias, canonical in raw_aliases.items()
-        if isinstance(canonical, str) and canonical in all_channels
-    }
-
-    logger.info(
-        "Channel annotations (API): %d identity, %d functional, %d aliases",
-        len(identity_channels), len(functional_channels), len(aliases),
-    )
-    return identity_channels, functional_channels, aliases
+    logger.info('Fetching channel annotations from API: %s', annotations_url)
+    annotations_file = _get_and_fill_buffer(annotations_url)
+    logger.info('Fetching channel aliases from API: %s', aliases_url)
+    aliases_file = _get_and_fill_buffer(aliases_url)
+    return load_channel_annotations_from_files(annotations_file, aliases_file)
 
 
 def normalize_name(name: str, aliases: dict) -> str:
     """Resolve a channel name to its canonical form via the aliases map."""
     return aliases.get(name, name)
+

--- a/smprofiler/atlas/channel_annotations.py
+++ b/smprofiler/atlas/channel_annotations.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from io import StringIO
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
+from smprofiler.atlas.cache import StandaloneSQLiteHTTPCache
 
 logger = colorized_logger(__name__)
 
@@ -75,10 +76,14 @@ def load_channel_annotations_from_api(
     return load_channel_annotations_from_files(annotations_file, aliases_file)
 
 def _get_and_fill_buffer(url: str, timeout: int) -> StringIO:
+    response_body = StandaloneSQLiteHTTPCache.retrieve_response(url)
+    if not response_body:
+        request = urllib.request.Request(url, headers={'Accept': 'application/json'})
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            response_body = response.read()
+            StandaloneSQLiteHTTPCache.cache_response(url, response_body)
     f = StringIO()
-    request = urllib.request.Request(url, headers={'Accept': 'application/json'})
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        f.write(response.read().decode())
+    f.write(response_body.decode())
     f.seek(0)
     return f
 

--- a/smprofiler/atlas/inference.py
+++ b/smprofiler/atlas/inference.py
@@ -1,17 +1,4 @@
 """Run a trained atlas-reference model to determine per-cell "atlas-relative" z-scores.
-
-Typical usage — starting from ONNX model (e.g. the ``/atlas-model/`` API
-endpoint, or local file)::
-
-    from smprofiler.atlas.inference import load_model, atlas_relative_positive
-
-    session = load_model(onnx_bytes)
-    # identity_intensities: shape (n_cells, n_identity), columns in the order of the
-    # model's `input_channels` metadata; measured_functional: shape (n_cells,).
-    z_score = atlas_relative_z_score(session, identity_intensities, measured_functional)
-
-Pass **raw** intensities: identity intensities are sum-normalized internally to
-match how the model was trained.
 """
 from typing import cast
 
@@ -68,16 +55,7 @@ def atlas_relative_positive(
     measured_functional,
 ) -> np.ndarray:
     """Boolean per cell: is the measured intensity above the atlas expectation?
-
-    Args:
-        session: session from :func:`load_model`.
-        identity_intensities: see :func:`predict_expected_intensity`.
-        measured_functional: array of shape ``(n_cells,)`` — the measured raw
-            intensity of the model's target (functional) channel.
-
-    Returns:
-        Boolean array of shape ``(n_cells,)``. Cells with no reference (zero
-        identity sum) are ``False``.
+    See ``compute_marker_z_score``.
     """
     z_score = compute_marker_z_score(session, identity_intensities, measured_functional)
     with np.errstate(invalid='ignore'):

--- a/smprofiler/atlas/inference.py
+++ b/smprofiler/atlas/inference.py
@@ -1,47 +1,39 @@
-"""Run a trained atlas-reference model to make per-cell "atlas-relative" calls.
+"""Run a trained atlas-reference model to determine per-cell "atlas-relative" z-scores.
 
-A model predicts the atlas-expected intensity of one functional marker for a
-"normal" cell with a given identity-marker profile. A cell is *atlas-relative
-positive* for that marker when its measured intensity exceeds this expectation.
-
-Typical usage — starting from ONNX bytes (e.g. the ``/atlas-model/`` API
-endpoint, or a file written by training)::
+Typical usage — starting from ONNX model (e.g. the ``/atlas-model/`` API
+endpoint, or local file)::
 
     from smprofiler.atlas.inference import load_model, atlas_relative_positive
 
     session = load_model(onnx_bytes)
     # identity_intensities: shape (n_cells, n_identity), columns in the order of the
     # model's `input_channels` metadata; measured_functional: shape (n_cells,).
-    positive = atlas_relative_positive(session, identity_intensities, measured_functional)
+    z_score = atlas_relative_z_score(session, identity_intensities, measured_functional)
 
 Pass **raw** intensities: identity intensities are sum-normalized internally to
-match how the model was trained, and the prediction is returned on the same raw
-scale as the measured value. Cells whose identity intensities sum to zero have no
-reference and are reported NaN / False.
+match how the model was trained.
 """
+from typing import cast
+
 import numpy as np
-from onnxruntime import InferenceSession, SessionOptions
+from numpy.typing import NDArray
+from onnxruntime import InferenceSession 
+from onnx import SessionOptions  # type: ignore  # because of import boundary for c API
 
 
 def load_model(onnx_model: bytes | str) -> InferenceSession:
     """Return an onnxruntime session for a model given as ONNX bytes or a file path."""
     options = SessionOptions()
-    options.log_severity_level = 3  # errors only
+    ERROR_LEVEL = 3
+    options.log_severity_level = ERROR_LEVEL
     return InferenceSession(onnx_model, sess_options=options)
 
-
-def _input_spec(session: InferenceSession) -> tuple[str, type]:
-    """The model's single input tensor name and the numpy dtype it expects."""
-    spec = session.get_inputs()[0]
-    dtype = np.float64 if spec.type == "tensor(double)" else np.float32
-    return spec.name, dtype
-
-
-def predict_expected_intensity(
+def compute_marker_z_score(
     session: InferenceSession,
-    identity_intensities,
+    identity_intensities: NDArray,
+    measured_functional: NDArray,
 ) -> np.ndarray:
-    """Atlas-expected functional-marker intensity for each cell.
+    """Atlas-relative functional-marker z-score.
 
     Args:
         session: session from :func:`load_model`.
@@ -50,25 +42,25 @@ def predict_expected_intensity(
             model's ``input_channels`` metadata.
 
     Returns:
-        Array of shape ``(n_cells,)``: the expected functional intensity on the
-        same raw scale as the measured intensity (so it is directly comparable).
-        Cells whose identity intensities sum to zero yield ``NaN``.
+        Array of shape ``(n_cells,)``.
     """
-    features = np.asarray(identity_intensities, dtype=np.float64)
-    if features.ndim != 2:
-        raise ValueError("identity_intensities must be 2-D: (n_cells, n_identity)")
-    row_sums = features.sum(axis=1)
+    X_unscaled = np.asarray(identity_intensities, dtype=np.float64)
+    if X_unscaled.ndim != 2:
+        raise ValueError('identity_intensities must be 2-D: (n_cells, n_identity)')
+    row_sums = X_unscaled.sum(axis=1)
     valid = row_sums > 0
-    normalized = np.zeros_like(features)
-    normalized[valid] = features[valid] / row_sums[valid, np.newaxis]
-
+    X = np.zeros_like(X_unscaled)
+    X[valid] = X_unscaled[valid] / row_sums[valid, np.newaxis]
+    y_measured = np.zeros_like(measured_functional)
+    y_measured[valid] = measured_functional / row_sums[valid]
     input_name, dtype = _input_spec(session)
-    predicted_normalized = session.run(None, {input_name: normalized.astype(dtype)})[0].reshape(-1)
-
-    expected = predicted_normalized * row_sums
-    expected[~valid] = np.nan
-    return expected
-
+    # For the below, see: https://onnx.ai/sklearn-onnx/auto_examples/plot_gpr.html#return-std-true
+    _y, _standard_deviation = cast(tuple[NDArray, NDArray], session.run(None, {input_name: X.astype(dtype)})[0])
+    y = _y.reshape(-1)
+    standard_deviation = _standard_deviation.reshape(-1)
+    z_score = (y_measured - y) / standard_deviation
+    z_score[~valid] = np.nan
+    return z_score
 
 def atlas_relative_positive(
     session: InferenceSession,
@@ -87,7 +79,13 @@ def atlas_relative_positive(
         Boolean array of shape ``(n_cells,)``. Cells with no reference (zero
         identity sum) are ``False``.
     """
-    expected = predict_expected_intensity(session, identity_intensities)
-    measured = np.asarray(measured_functional, dtype=np.float64).reshape(-1)
-    with np.errstate(invalid="ignore"):  # NaN expectations compare False
-        return measured > expected
+    z_score = compute_marker_z_score(session, identity_intensities, measured_functional)
+    with np.errstate(invalid='ignore'):
+        return z_score > 0
+
+def _input_spec(session: InferenceSession) -> tuple[str, type]:
+    """The model's single input tensor name and the numpy dtype it expects."""
+    spec = session.get_inputs()[0]
+    dtype = np.float64 if spec.type == 'tensor(double)' else np.float32
+    return spec.name, dtype
+

--- a/smprofiler/atlas/model_selection_fitting.py
+++ b/smprofiler/atlas/model_selection_fitting.py
@@ -6,8 +6,6 @@ import time
 from numpy.typing import NDArray
 from sklearn.linear_model import BayesianRidge
 from sklearn.model_selection import cross_val_score
-from sklearn.preprocessing import Normalizer
-from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import Pipeline
 from tqdm import tqdm
 
@@ -33,7 +31,7 @@ def train_and_select_best(
     performances: list[tuple[float, float]] = []
     for name, model_architecture in tqdm(candidates, desc='  CV candidates', leave=False, bar_format=bar_format):
         mean_r2, std_r2, elapsed = _score_architecture_on_data(model_architecture, X_train, y_train, cv_folds)
-        logger.info('    %-28s R²=%+.4f ± %.4f  [%s]%s', name, mean_r2, std_r2, elapsed)
+        logger.info('    %-28s R²=%+.4f ± %.4f  [%s]', name, mean_r2, std_r2, elapsed)
         performances.append((mean_r2, std_r2))
     def key(item: tuple[tuple[str, Pipeline], tuple[float, float]]):
         return item[1][0]
@@ -59,8 +57,6 @@ def build_model_candidates() -> list[tuple[str, Pipeline]]:
         (
             'bayesian_ridge',
             Pipeline([
-                ('normalizer', Normalizer(norm='l1')),
-                ('scaler', StandardScaler()),
                 ('bayesian_ridge', BayesianRidge()),
             ]),
         ),

--- a/smprofiler/atlas/model_selection_fitting.py
+++ b/smprofiler/atlas/model_selection_fitting.py
@@ -33,8 +33,7 @@ def train_and_select_best(
     performances: list[tuple[float, float]] = []
     for name, model_architecture in tqdm(candidates, desc='  CV candidates', leave=False, bar_format=bar_format):
         mean_r2, std_r2, elapsed = _score_architecture_on_data(model_architecture, X_train, y_train, cv_folds)
-        marker = ' ★' if mean_r2 > best_r2 else ''
-        logger.info('    %-28s R²=%+.4f ± %.4f  [%s]%s', name, mean_r2, std_r2, elapsed, marker)
+        logger.info('    %-28s R²=%+.4f ± %.4f  [%s]%s', name, mean_r2, std_r2, elapsed)
         performances.append((mean_r2, std_r2))
     def key(item: tuple[tuple[str, Pipeline], tuple[float, float]]):
         return item[1][0]
@@ -42,15 +41,15 @@ def train_and_select_best(
     logger.info('  → Refitting winner "%s" on full train set…', best_name)
     t0 = time.monotonic()
     best_model.fit(X_train, y_train)
+    fitted_best_model = best_model
     elapsed = format_elapsed(time.monotonic() - t0)
     logger.info('  → Done in %s  (CV R²=%.4f ± %.4f)', elapsed, best_r2, best_std)
-    return best_name, best_model, best_r2, best_std
+    return best_name, fitted_best_model, best_r2, best_std
 
 
 def build_model_candidates() -> list[tuple[str, Pipeline]]:
     """
     Return list of (name, sklearn_estimator) for all candidate models.
-
     This should include available model architectures for which:
 
     1. Computational complexity is not prohibitive for sample sizes of order around 100k.

--- a/smprofiler/atlas/models.py
+++ b/smprofiler/atlas/models.py
@@ -1,28 +1,14 @@
-"""Regression model candidates, cross-validated selection, and prediction.
-
-Only architectures whose predictive standard deviation genuinely depends on the
-input ``x`` are considered — so that the per-cell "atlas-relative" call can use a
-context-aware uncertainty, not a single global residual std. Concretely:
-
-- ``bayesian_ridge`` — Bayesian posterior predictive std,
-- ``gaussian_process`` — GP posterior predictive std,
-- ``random_forest`` / ``extra_trees`` — spread across the individual trees.
-
-Purely-mean regressors (ridge, elastic net, huber, gradient boosting) are
-excluded because they offer only an input-independent residual std.
-``predict_with_std`` raises for any model outside this set, keeping the invariant
-enforced in code.
+"""
+Regression model candidates, cross-validated selection, and prediction.
 """
 import time
 
-import numpy as np
-from sklearn.ensemble import ExtraTreesRegressor, RandomForestRegressor
-from sklearn.gaussian_process import GaussianProcessRegressor
-from sklearn.gaussian_process.kernels import RBF, ConstantKernel, WhiteKernel
+from numpy.typing import NDArray
 from sklearn.linear_model import BayesianRidge
 from sklearn.model_selection import cross_val_score
-from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import Normalizer
 from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
 from tqdm import tqdm
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
@@ -30,158 +16,69 @@ from smprofiler.atlas.reporting import format_elapsed
 
 logger = colorized_logger(__name__)
 
-# GaussianProcessRegressor is O(n^3) in training-set size; fit it on at most this
-# many (randomly sampled) cells. Other candidates train on the full set.
-MAX_GP_TRAIN_SAMPLES = 2000
-
-# Models whose predictive std depends on x (see module docstring).
-STD_METHODS = {
-    "bayesian_ridge": "bayesian_posterior",
-    "gaussian_process": "gaussian_posterior",
-    "random_forest": "tree_variance",
-    "extra_trees": "tree_variance",
-}
-
-
-def build_model_candidates() -> list[tuple[str, object]]:
-    """Return list of (name, sklearn_estimator) for all candidate models.
-
-    Every candidate exposes an input-dependent predictive std via
-    :func:`predict_with_std`; see the module docstring.
-    """
-    gp_kernel = ConstantKernel(1.0) * RBF(length_scale=1.0) + WhiteKernel(noise_level=1.0)
-    return [
-        (
-            "extra_trees",
-            ExtraTreesRegressor(
-                n_estimators=100,
-                max_depth=8,
-                n_jobs=-1,
-                random_state=42,
-            ),
-        ),
-        (
-            "random_forest",
-            RandomForestRegressor(
-                n_estimators=100,
-                max_depth=8,
-                n_jobs=-1,
-                random_state=42,
-            ),
-        ),
-        (
-            "bayesian_ridge",
-            Pipeline([
-                ("scaler", StandardScaler()),
-                ("bayesian_ridge", BayesianRidge()),
-            ]),
-        ),
-        (
-            "gaussian_process",
-            Pipeline([
-                ("scaler", StandardScaler()),
-                ("gaussian_process", GaussianProcessRegressor(
-                    kernel=gp_kernel,
-                    normalize_y=True,
-                    random_state=42,
-                )),
-            ]),
-        ),
-    ]
-
-
-def _training_data_for(
-    name: str,
-    X_train: np.ndarray,
-    y_train: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Bound the Gaussian Process training set; pass others through unchanged."""
-    if name == "gaussian_process" and len(X_train) > MAX_GP_TRAIN_SAMPLES:
-        rng = np.random.default_rng(42)
-        idx = rng.choice(len(X_train), size=MAX_GP_TRAIN_SAMPLES, replace=False)
-        return X_train[idx], y_train[idx]
-    return X_train, y_train
-
 
 def train_and_select_best(
-    X_train: np.ndarray,
-    y_train: np.ndarray,
+    X_train: NDArray,
+    y_train: NDArray,
     cv_folds: int = 5,
-) -> tuple[str, object, float, float]:
+) -> tuple[str, Pipeline, float, float]:
     """
-    Train all candidate models with k-fold CV, select the one with highest R².
+    Train all candidate models with k-fold cross-validation, select the one with highest R².
 
     Returns:
         (best_model_name, fitted_best_model, cv_r2_mean, cv_r2_std)
     """
     candidates = build_model_candidates()
-    best_name = None
-    best_model = None
-    best_r2 = -np.inf
-    best_std = np.nan
-
-    for name, model in tqdm(candidates, desc="  CV candidates", leave=False,
-                            bar_format="  {desc}: {n_fmt}/{total_fmt} [{bar}] {postfix}"):
-        t0 = time.monotonic()
-        X_cv, y_cv = _training_data_for(name, X_train, y_train)
-        scores = cross_val_score(
-            model, X_cv, y_cv,
-            cv=cv_folds, scoring="r2", n_jobs=-1,
-        )
-        mean_r2 = float(scores.mean())
-        std_r2 = float(scores.std())
-        elapsed = format_elapsed(time.monotonic() - t0)
-        marker = " ★" if mean_r2 > best_r2 else ""
-        logger.info("    %-28s R²=%+.4f ± %.4f  [%s]%s",
-                    name, mean_r2, std_r2, elapsed, marker)
-
-        if mean_r2 > best_r2:
-            best_r2 = mean_r2
-            best_std = std_r2
-            best_name = name
-            best_model = model
-
-    # Refit best model on the full training set (subsampled for GP).
-    logger.info("  → Refitting winner '%s' on full train set…", best_name)
+    bar_format = '  {desc}: {n_fmt}/{total_fmt} [{bar}] {postfix}'
+    performances: list[tuple[float, float]] = []
+    for name, model_architecture in tqdm(candidates, desc='  CV candidates', leave=False, bar_format=bar_format):
+        mean_r2, std_r2, elapsed = _score_architecture_on_data(model_architecture, X_train, y_train, cv_folds)
+        marker = ' ★' if mean_r2 > best_r2 else ''
+        logger.info('    %-28s R²=%+.4f ± %.4f  [%s]%s', name, mean_r2, std_r2, elapsed, marker)
+        performances.append((mean_r2, std_r2))
+    def key(item: tuple[tuple[str, Pipeline], tuple[float, float]]):
+        return item[1][0]
+    (best_name, best_model), (best_r2, best_std) = sorted(list(zip(candidates, performances)), key=key, reverse=True)[0]
+    logger.info('  → Refitting winner "%s" on full train set…', best_name)
     t0 = time.monotonic()
-    X_fit, y_fit = _training_data_for(best_name, X_train, y_train)
-    best_model.fit(X_fit, y_fit)
-    logger.info("  → Done in %s  (CV R²=%.4f ± %.4f)",
-                format_elapsed(time.monotonic() - t0), best_r2, best_std)
+    best_model.fit(X_train, y_train)
+    elapsed = format_elapsed(time.monotonic() - t0)
+    logger.info('  → Done in %s  (CV R²=%.4f ± %.4f)', elapsed, best_r2, best_std)
     return best_name, best_model, best_r2, best_std
 
 
-def predict_with_std(
-    model,
-    model_name: str,
-    X_norm: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray]:
+def build_model_candidates() -> list[tuple[str, Pipeline]]:
     """
-    Return (y_mean, y_std) for a fitted model evaluated on normalized inputs.
+    Return list of (name, sklearn_estimator) for all candidate models.
 
-    y_std is a per-sample predictive std that depends on the input.
+    This should include available model architectures for which:
 
-    Dispatch rules:
-        bayesian_ridge   → posterior predictive std from BayesianRidge.predict()
-        gaussian_process → posterior predictive std from GaussianProcessRegressor
-        random_forest / extra_trees → std across individual tree predictions
-
-    Raises:
-        ValueError: for any model whose std would not depend on the input.
+    1. Computational complexity is not prohibitive for sample sizes of order around 100k.
+    2. Per-sample standard deviation is an ordinary model output along with (mean) prediction.
     """
-    if model_name in ("bayesian_ridge", "gaussian_process"):
-        X_scaled = model.named_steps["scaler"].transform(X_norm)
-        inner = model.named_steps[model_name]
-        y_mean, y_std = inner.predict(X_scaled, return_std=True)
-        return y_mean, y_std
+    return [
+        (
+            'bayesian_ridge',
+            Pipeline([
+                ('normalizer', Normalizer(norm='l1')),
+                ('scaler', StandardScaler()),
+                ('bayesian_ridge', BayesianRidge()),
+            ]),
+        ),
+    ]
 
-    if model_name in ("random_forest", "extra_trees"):
-        tree_preds = np.stack(
-            [t.predict(X_norm) for t in model.estimators_], axis=0
-        )  # (n_trees, n_samples)
-        return tree_preds.mean(axis=0), tree_preds.std(axis=0)
 
-    raise ValueError(
-        f"Model '{model_name}' has no input-dependent predictive std; only "
-        f"{sorted(STD_METHODS)} are supported."
-    )
+def _score_architecture_on_data(
+    architecture: Pipeline,
+    X: NDArray,
+    y: NDArray,
+    cv_folds: int,
+) -> tuple[float, float, str]:
+    t0 = time.monotonic()
+    scores = cross_val_score(architecture, X, y, cv=cv_folds, scoring='r2', n_jobs=-1)
+    mean_r2 = float(scores.mean())
+    std_r2 = float(scores.std())
+    elapsed = format_elapsed(time.monotonic() - t0)
+    return mean_r2, std_r2, elapsed
+
+

--- a/smprofiler/atlas/reporting.py
+++ b/smprofiler/atlas/reporting.py
@@ -1,44 +1,25 @@
-"""Progress reporting and logging helpers for atlas model training.
-
-Per-module log messages use the codebase-standard ``colorized_logger``. This
-module holds the few shared extras that pattern doesn't cover:
-
-- ``section`` / ``subsection``: visual dividers for the CLI's human-facing
-  progress output, printed (not logged) so they stand out from timestamped log
-  lines and align with the final summary table (see ``training.run``). Printing
-  such output matches the codebase (e.g. ``entry_point/cli.py``,
-  ``db/scripts/status.py``).
-- ``format_elapsed``: shared elapsed-time formatting, used across modules.
-- ``suppress_third_party_logging`` / ``set_atlas_log_level``: standard-logging
-  level tweaks for the ONNX libraries and the ``--verbose`` flag.
+"""
+Progress reporting and logging helpers for atlas model training.
 """
 import logging
 
-# Width of visual separator lines.
-_SEP_WIDTH = 70
+_SEPARATOR_WIDTH = 70
 
-# ONNX-ecosystem loggers clamped to WARNING by suppress_third_party_logging
-# (defensive — these are usually quiet, but stay silent across library versions).
 _NOISY_LOGGERS = ('skl2onnx', 'onnx', 'onnxruntime')
 
 
 def section(title: str) -> None:
-    """Print a prominent section header to stdout (bypasses log timestamps)."""
-    bar = '═' * _SEP_WIDTH
+    bar = '═' * _SEPARATOR_WIDTH
     print(f'\n{bar}', flush=True)
     print(f'  {title}', flush=True)
     print(bar, flush=True)
 
-
 def subsection(title: str) -> None:
-    """Print a lighter sub-section divider."""
-    print(f"\n{'─' * _SEP_WIDTH}", flush=True)
+    print(f"\n{'─' * _SEPARATOR_WIDTH}", flush=True)
     print(f'  {title}', flush=True)
-    print(f"{'─' * _SEP_WIDTH}", flush=True)
-
+    print(f"{'─' * _SEPARATOR_WIDTH}", flush=True)
 
 def format_elapsed(seconds: float) -> str:
-    """Return a human-readable elapsed time string."""
     minutes, secs = divmod(int(seconds), 60)
     hours, minutes = divmod(minutes, 60)
     if hours:
@@ -47,19 +28,13 @@ def format_elapsed(seconds: float) -> str:
         return f'{minutes}m {secs}s'
     return f'{secs}s'
 
-
 def suppress_third_party_logging() -> None:
-    """Quiet the verbose ONNX ecosystem loggers down to WARNING."""
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
 
-
 def set_atlas_log_level(verbose: bool) -> None:
-    """Set the verbosity of every ``smprofiler.atlas`` logger.
-
-    ``colorized_logger`` configures each module logger at DEBUG; this gates
-    DEBUG output behind the caller's ``--verbose`` choice without disturbing
-    the shared colorized handler/format used across the codebase.
+    """
+    Set the verbosity of every ``smprofiler.atlas`` logger.
     """
     level = logging.DEBUG if verbose else logging.INFO
     for name, logger in logging.Logger.manager.loggerDict.items():
@@ -67,3 +42,4 @@ def set_atlas_log_level(verbose: bool) -> None:
             logger.setLevel(level)
             for handler in logger.handlers:
                 handler.setLevel(level)
+

--- a/smprofiler/atlas/scripts/train_atlas_models.py
+++ b/smprofiler/atlas/scripts/train_atlas_models.py
@@ -1,16 +1,6 @@
 #!/usr/bin/env python3
 """Command line entry point for atlas-reference model training.
 
-For each (study, functional_marker) pair, trains a regression model on the
-aggregated Allen Institute Human Immune Health Atlas expression table that
-predicts functional marker intensity from identity marker values, and exports
-it to ONNX. The atlas expression table (Parquet) and the SPT-channel → atlas-
-gene mapping (TSV) are produced by the atlas aggregation step in
-smprofiler-data. See ``smprofiler.atlas`` for the library implementation.
-
-Channel annotations are fetched from the smprofiler API (the source of truth);
-loading them from a local file is deprecated and no longer supported here.
-
 Example:
     smprofiler atlas train-atlas-models \\
         --atlas-parquet /path/to/cell_atlas_small.parquet \\
@@ -21,6 +11,7 @@ Example:
 """
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from smprofiler.standalone_utilities.module_load_error import SuggestExtrasException
@@ -49,7 +40,7 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(
         prog='smprofiler atlas train-atlas-models',
-        description="Train atlas-reference regression models for SPT",
+        description="Train atlas-reference regression models for SMProfiler",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -60,7 +51,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--channel-mapping",
         default=str(data_dir / "smprofiler_channels_to_atlas.tsv"),
-        help="Path to the SPT-channel → atlas-gene mapping (smprofiler_channels_to_atlas.tsv)",
+        help="Path to the SMProfiler-channel → atlas-gene mapping (smprofiler_channels_to_atlas.tsv)",
     )
     parser.add_argument(
         "--datasets-dir",
@@ -75,11 +66,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--annotations-api-url",
         default=DEFAULT_ANNOTATIONS_API_URL,
-        help=(
-            "Base URL for the smprofiler API used to fetch channel annotations "
-            "(the sole source; loading from a local file is deprecated). The run "
-            "fails if the API is unreachable."
-        ),
+        help="Base URL for the smprofiler API used to fetch channel annotations",
     )
     parser.add_argument(
         "--max-cells",
@@ -127,6 +114,7 @@ def main(args: argparse.Namespace) -> None:
         from smprofiler.atlas.reporting import suppress_third_party_logging
     except ModuleNotFoundError as exception:
         SuggestExtrasException(exception, 'atlas')
+        raise exception
 
     suppress_third_party_logging()
     set_atlas_log_level(args.verbose)
@@ -145,9 +133,10 @@ def main(args: argparse.Namespace) -> None:
             database_config_file=Path(args.database_config_file) if args.database_config_file else None,
         )
     except (FileNotFoundError, RuntimeError) as exception:
-        logger.error("%s", exception)
-        raise SystemExit(1) from exception
+        logger.error('%s', exception)
+        sys.exit(1)
 
 
 if __name__ == "__main__":
     main(parse_args())
+

--- a/smprofiler/atlas/study_channels.py
+++ b/smprofiler/atlas/study_channels.py
@@ -1,14 +1,11 @@
-"""Per-study channel discovery.
-
-Locates channel-definition files inside each study's dataset directory and
-splits the discovered channels into identity / functional lists according to
-the global channel annotation groups.
 """
-from pathlib import Path
+Per-study ordered channel (marker) retrieval. Also splits the discovered channels
+into identity / functional lists according to the global channel annotation groups.
+"""
 from urllib import request
 from urllib.parse import quote_plus
+import json
 
-import pandas as pd
 from attrs import define
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
@@ -18,47 +15,21 @@ from smprofiler.db.exchange_data_formats.metrics import Channel
 logger = colorized_logger(__name__)
 
 @define
+class StudyChannel:
+    study_specific: str
+    smprofiler_normalized: str
+    atlas_specific: str
+
+@define
 class StudyOrderedChannels:
-    identity: tuple[str, ...]
-    functional: tuple[str, ...]
-
-def _read_channel_names_from_file(path: Path, aliases: dict) -> list[str]:
-    """
-    Read channel names from an elementary_phenotypes or channels file.
-
-    Handles:
-    - CSV / TSV with 'Symbol' column  (elementary_phenotypes_overlay.csv)
-    - CSV / TSV with 'Name' column    (elementary_phenotypes.csv, channels.tsv)
-    """
-    sep = "\t" if path.suffix == ".tsv" else ","
-    try:
-        df = pd.read_csv(path, sep=sep)
-    except Exception as exc:
-        logger.warning("Could not read %s: %s", path, exc)
-        return []
-
-    col = None
-    for candidate in ("Symbol", "Name"):
-        if candidate in df.columns:
-            col = candidate
-            break
-
-    if col is None:
-        logger.warning("No 'Symbol' or 'Name' column in %s (columns: %s)", path, list(df.columns))
-        return []
-
-    names = []
-    for raw in df[col].dropna():
-        canonical = normalize_name(str(raw).strip(), aliases)
-        names.append(canonical)
-    logger.debug("  %s: %d channel names read (column '%s')", path.name, len(names), col)
-    return names
-
+    identity: tuple[StudyChannel, ...]
+    functional: tuple[StudyChannel, ...]
 
 def _retrieve_study_channels_from_api(
     study: str,
     identity_channels: tuple[str, ...],
     aliases: dict[str, str],
+    smprofiler_to_atlas: dict[str, str],
     base_url: str,
     timeout: int = 30,
 ) -> StudyOrderedChannels:
@@ -66,12 +37,19 @@ def _retrieve_study_channels_from_api(
     url = f'{base}/channels/?study={quote_plus(study)}'
     r = request.Request(url, headers={'Accept': 'application/json'})
     with request.urlopen(r, timeout=timeout) as response:
-        data: list[Channel] = response.read().decode()
-    names = tuple(map(lambda c: normalize_name(c.symbol, aliases), data))
-    identity = tuple(filter(lambda n: n in identity_channels, names))
-    functional = tuple(filter(lambda n: n not in identity_channels, names))
+        x = json.load(response)
+        data: list[Channel] = [Channel.model_validate_json(json.dumps(item)) for item in x]
+    channels = []
+    for c in data:
+        study_specific = c.symbol
+        smprofiler_normalized = normalize_name(study_specific, aliases)
+        atlas_specific = smprofiler_to_atlas.get(smprofiler_normalized, None)
+        if atlas_specific is None:
+            continue
+        channels.append(StudyChannel(study_specific, smprofiler_normalized, atlas_specific))
+    identity = tuple(filter(lambda c: c.smprofiler_normalized in identity_channels, channels))
+    functional = tuple(filter(lambda c: c.smprofiler_normalized not in identity_channels, channels))
     return StudyOrderedChannels(identity, functional)
-
 
 def retrieve_all_study_channels_from_api(
     studies: tuple[str, ...],
@@ -84,71 +62,3 @@ def retrieve_all_study_channels_from_api(
     ))
 
 
-def discover_study_channels(
-    datasets_dir: Path,
-    studies: list[str],
-    identity_channels: set,
-    aliases: dict,
-) -> dict[str, dict]:
-    """
-    For each study, locate channel definition files and split into identity /
-    functional lists based on the global channel annotation groups.
-
-    Returns:
-        dict mapping study_name → {
-            "identity": [channel, ...],
-            "functional": [channel, ...],
-        }
-    """
-
-    results = {}
-    for study_name in studies:
-        study_dir = datasets_dir / study_name
-        if not study_dir.is_dir():
-            logger.warning("Dataset directory not found: %s", study_dir)
-            continue
-
-        all_names: list[str] = []
-        pattern = '**/generated_artifacts/elementary_phenotypes.csv'
-        files = sorted(study_dir.glob(pattern))
-        for f in files:
-            names = _read_channel_names_from_file(f, aliases)
-            all_names.extend(names)
-        if all_names:
-            break  # stop searching once we found something
-
-        if not all_names:
-            logger.warning("No channel files found for study '%s' – skipping", study_name)
-            continue
-
-        # Deduplicate while preserving order
-        seen: set = set()
-        unique_names = []
-        for n in all_names:
-            if n not in seen:
-                seen.add(n)
-                unique_names.append(n)
-
-        logger.info(
-            "Study '%s': %d unique channels in dataset files",
-            study_name, len(unique_names),
-        )
-        identity = [n for n in unique_names if n in identity_channels]
-        functional = [n for n in unique_names if n in functional_channels]
-
-        if not identity:
-            logger.warning("Study '%s': no identity channels found, skipping", study_name)
-            continue
-        if not functional:
-            logger.warning("Study '%s': no functional channels found, skipping", study_name)
-            continue
-
-        results[study_name] = {"identity": identity, "functional": functional}
-        logger.info(
-            "Study '%s': %d identity channels, %d functional channels",
-            study_name, len(identity), len(functional),
-        )
-        logger.debug("  Identity:   %s", identity)
-        logger.debug("  Functional: %s", functional)
-
-    return results

--- a/smprofiler/atlas/study_channels.py
+++ b/smprofiler/atlas/study_channels.py
@@ -50,6 +50,9 @@ def _retrieve_study_channels_from_api(
         smprofiler_normalized = normalize_name(study_specific, aliases)
         atlas_specific = smprofiler_to_atlas.get(smprofiler_normalized, None)
         if atlas_specific is None:
+            logger.warning(
+                f'Could not resolve study_specific="{study_specific}" or smprofiler_normalized={smprofiler_normalized} to atlas name.'
+            )
             continue
         channels.append(StudyChannel(study_specific, smprofiler_normalized, atlas_specific))
     identity = tuple(filter(lambda c: c.smprofiler_normalized in identity_channels, channels))

--- a/smprofiler/atlas/study_channels.py
+++ b/smprofiler/atlas/study_channels.py
@@ -9,6 +9,7 @@ import json
 from attrs import define
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
+from smprofiler.atlas.cache import StandaloneSQLiteHTTPCache
 from smprofiler.atlas.channel_annotations import normalize_name
 from smprofiler.db.exchange_data_formats.metrics import Channel
 
@@ -35,10 +36,14 @@ def _retrieve_study_channels_from_api(
 ) -> StudyOrderedChannels:
     base = base_url.rstrip('/')
     url = f'{base}/channels/?study={quote_plus(study)}'
-    r = request.Request(url, headers={'Accept': 'application/json'})
-    with request.urlopen(r, timeout=timeout) as response:
-        x = json.load(response)
-        data: list[Channel] = [Channel.model_validate_json(json.dumps(item)) for item in x]
+    response_body = StandaloneSQLiteHTTPCache.retrieve_response(url)
+    if response_body is None:
+        r = request.Request(url, headers={'Accept': 'application/json'})
+        with request.urlopen(r, timeout=timeout) as response:
+            response_body = response.read()
+            StandaloneSQLiteHTTPCache.cache_response(url, response_body)
+    x = json.loads(response_body.decode())
+    data: list[Channel] = [Channel.model_validate_json(json.dumps(item)) for item in x]
     channels = []
     for c in data:
         study_specific = c.symbol

--- a/smprofiler/atlas/study_channels.py
+++ b/smprofiler/atlas/study_channels.py
@@ -5,14 +5,22 @@ splits the discovered channels into identity / functional lists according to
 the global channel annotation groups.
 """
 from pathlib import Path
+from urllib import request
+from urllib.parse import quote_plus
 
 import pandas as pd
+from attrs import define
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 from smprofiler.atlas.channel_annotations import normalize_name
+from smprofiler.db.exchange_data_formats.metrics import Channel
 
 logger = colorized_logger(__name__)
 
+@define
+class StudyOrderedChannels:
+    identity: tuple[str, ...]
+    functional: tuple[str, ...]
 
 def _read_channel_names_from_file(path: Path, aliases: dict) -> list[str]:
     """
@@ -47,11 +55,39 @@ def _read_channel_names_from_file(path: Path, aliases: dict) -> list[str]:
     return names
 
 
+def _retrieve_study_channels_from_api(
+    study: str,
+    identity_channels: tuple[str, ...],
+    aliases: dict[str, str],
+    base_url: str,
+    timeout: int = 30,
+) -> StudyOrderedChannels:
+    base = base_url.rstrip('/')
+    url = f'{base}/channels/?study={quote_plus(study)}'
+    r = request.Request(url, headers={'Accept': 'application/json'})
+    with request.urlopen(r, timeout=timeout) as response:
+        data: list[Channel] = response.read().decode()
+    names = tuple(map(lambda c: normalize_name(c.symbol, aliases), data))
+    identity = tuple(filter(lambda n: n in identity_channels, names))
+    functional = tuple(filter(lambda n: n not in identity_channels, names))
+    return StudyOrderedChannels(identity, functional)
+
+
+def retrieve_all_study_channels_from_api(
+    studies: tuple[str, ...],
+    *args,
+    **kwargs,
+) -> tuple[StudyOrderedChannels, ...]:
+    return tuple(map(
+        lambda study: _retrieve_study_channels_from_api(study, *args, **kwargs),
+        studies,
+    ))
+
+
 def discover_study_channels(
     datasets_dir: Path,
     studies: list[str],
     identity_channels: set,
-    functional_channels: set,
     aliases: dict,
 ) -> dict[str, dict]:
     """
@@ -64,13 +100,6 @@ def discover_study_channels(
             "functional": [channel, ...],
         }
     """
-    # File name patterns to search, in priority order:
-    # overlay files use 'Symbol' column; others use 'Name' column
-    candidates_patterns = [
-        "**/elementary_phenotypes_overlay*.csv",
-        "**/elementary_phenotypes.csv",
-        "**/channels.tsv",
-    ]
 
     results = {}
     for study_name in studies:
@@ -80,13 +109,13 @@ def discover_study_channels(
             continue
 
         all_names: list[str] = []
-        for pattern in candidates_patterns:
-            files = sorted(study_dir.glob(pattern))
-            for f in files:
-                names = _read_channel_names_from_file(f, aliases)
-                all_names.extend(names)
-            if all_names:
-                break  # stop searching once we found something
+        pattern = '**/generated_artifacts/elementary_phenotypes.csv'
+        files = sorted(study_dir.glob(pattern))
+        for f in files:
+            names = _read_channel_names_from_file(f, aliases)
+            all_names.extend(names)
+        if all_names:
+            break  # stop searching once we found something
 
         if not all_names:
             logger.warning("No channel files found for study '%s' – skipping", study_name)

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -1,27 +1,28 @@
 """Atlas-reference model training pipeline.
 
-Orchestrates the end-to-end run: load channel annotations, discover per-study
-identity/functional channels, map SPT channels onto atlas genes (via the manual
-mapping produced by the aggregation step), then read the aggregated atlas
-expression table (Parquet) and train and export one regression model per
-(study, functional_marker) pair.
+Orchestrates the end-to-end run:
+- Load channel annotations
+- Determine available per-study identity/functional channels
+- Map SMProfiler channels onto atlas genes (via the manually-maintained mapping)
+- Read the aggregated atlas expression table (Parquet)
+- Train and export one regression model per (study, functional_marker) and reference dataset
 
-``run`` is plain library code — it takes explicit arguments and raises on
-error. The command line adapter lives in
-``smprofiler.atlas.scripts.train_atlas_models``.
+The command line adapter for ``run`` lives in ``smprofiler.atlas.scripts.train_atlas_models``.
 """
 import pickle
 import time
 from pathlib import Path
+from json import read as json_read
 
 import numpy as np
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.model_selection import train_test_split
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
+from smprofiler.db.study_tokens import StudyCollectionNaming
 from smprofiler.atlas.reporting import format_elapsed, section, subsection
 from smprofiler.atlas.channel_annotations import load_channel_annotations_from_api
-from smprofiler.atlas.study_channels import discover_study_channels
+from smprofiler.atlas.study_channels import retrieve_all_study_channels_from_api
 from smprofiler.atlas.atlas_data import load_atlas_gene_names
 from smprofiler.atlas.atlas_data import load_atlas_subset
 from smprofiler.atlas.atlas_data import load_channel_mapping
@@ -33,28 +34,18 @@ from smprofiler.atlas.artifacts import export_to_onnx, validate_onnx, write_meta
 
 logger = colorized_logger(__name__)
 
-ATLAS_VERSION = "allen-human-immune-health-atlas-2025"
-
-DEFAULT_ANNOTATIONS_API_URL = "https://smprofiler.io/api"
-
-# Width of the final-summary rule (matches the section dividers in reporting).
+ATLAS_VERSION = 'allen-human-immune-health-atlas-2025'
+DEFAULT_ANNOTATIONS_API_URL = 'https://smprofiler.io/api'
 _SUMMARY_WIDTH = 70
 
-
-def _store_models_in_db(database_config_file: Path, records: list[dict]) -> None:
-    """Persist trained models to the metaschema ``atlas_model`` table (one connection)."""
+def _store_models_in_db(database_config_file: Path, model_records: list[dict]) -> None:
     # Imported lazily so the file-only training path carries no database dependency.
-    from smprofiler.db.database_connection import DBCursor
-    from smprofiler.db.accessors.atlas_models import store_atlas_model
-
-    logger.info("Storing %d trained model(s) to the 'atlas_model' database table…", len(records))
-    with DBCursor(database_config_file=str(database_config_file)) as cursor:
-        for record in records:
-            store_atlas_model(cursor, **record)
+    from smprofiler.db.accessors.atlas_models import store_models_in_db
+    store_models_in_db(database_config_file, model_records) 
 
 
 def run(
-    parquet_path: Path,
+    parquet_atlas_path: Path,
     mapping_path: Path,
     datasets_dir: Path,
     output_dir: Path,
@@ -70,122 +61,126 @@ def run(
     Train atlas-reference regression models.
 
     Args:
-        parquet_path: path to the aggregated atlas expression table
-            (cell_atlas_small.parquet) — cells × atlas genes.
-        mapping_path: path to the manual SPT-channel → atlas-gene mapping
+        parquet_atlas_path: path to the aggregated atlas expression table
+            (file cell_atlas_small.parquet) is cells × atlas genes.
+        mapping_path: path to the manual SMProfiler-channel → atlas-gene mapping
             (smprofiler_channels_to_atlas.tsv).
         datasets_dir: root directory containing per-study dataset folders.
         output_dir: directory for ONNX models, pickles, and metadata.
-        annotations_api_url: smprofiler API base URL — the sole source of channel
-            annotations. Loading annotations from a local file is deprecated, so
-            this must be set; if the API is unreachable the run fails rather than
-            silently falling back to a possibly-stale file.
+        annotations_api_url: smprofiler API base URL - the source of channel
+            annotations.
         max_cells: max atlas cells to use (random sample); None uses all cells.
         study: train only for this study; None discovers all studies.
         cv_folds: number of cross-validation folds.
         dry_run: print the training plan without training any models.
-        database_config_file: if given, also store each trained model (ONNX bytes
-            + metadata) in the metaschema ``atlas_model`` table; None writes files only.
+        database_config_file: if given, also store each trained model (ONNX model
+        file + metadata) in the ``atlas_model`` table; None writes files only.
 
     Raises:
-        FileNotFoundError: if a required input file is missing.
-        RuntimeError: if annotations cannot be loaded from the API, or if no
+        FileNotFoundError
+        RuntimeError if annotations cannot be loaded from the API, or if no
             studies with usable channel data are found.
     """
-    if not parquet_path.exists():
-        raise FileNotFoundError(f"Atlas parquet file not found: {parquet_path}")
+    if not parquet_atlas_path.exists():
+        raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
     if not mapping_path.exists():
-        raise FileNotFoundError(f"Channel mapping file not found: {mapping_path}")
+        raise FileNotFoundError(f'Channel mapping file not found: {mapping_path}')
 
     if not annotations_api_url:
         raise RuntimeError(
-            "An annotations API URL is required — loading channel annotations from "
-            "a local file is deprecated. Set annotations_api_url."
+            'An annotations API URL is required — loading channel annotations from '
+            'a local file is deprecated. Set annotations_api_url.'
         )
     try:
-        identity_channels, functional_channels, aliases = load_channel_annotations_from_api(
+        identity_channels, aliases = load_channel_annotations_from_api(
             annotations_api_url
         )
     except Exception as exc:
         raise RuntimeError(
-            f"Failed to load channel annotations from API {annotations_api_url}: {exc}"
+            f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
         ) from exc
 
     if study:
-        study_list = [study]
+        study_handles = [study]
     else:
-        study_list = [
+        study_handles = [
             d.name for d in sorted(datasets_dir.iterdir())
-            if d.is_dir() and d.name != "template"
+            if d.is_dir() and d.name != 'template'
         ]
 
-    study_channels = discover_study_channels(
-        datasets_dir, study_list, identity_channels, functional_channels, aliases
-    )
+    _study_names = []
+    for handle in study_handles:
+        study_json = datasets_dir / handle / 'generated_artifacts' / 'study.json'
+        if not study_json.exists():
+            logger.warning("Dataset metadata not found for: %s", handle)
+            continue
+        _study_names.append(StudyCollectionNaming.extract_study_from_file(study_json))
+    study_names = tuple(_study_names)
 
-    if not study_channels:
-        raise RuntimeError("No studies with channel data found.")
+    study_channels = retrieve_all_study_channels_from_api(
+        study_names, identity_channels, aliases, base_url=annotations_api_url
+    )
 
     # Keep only mapped channels whose atlas gene is actually present in the Parquet table.
     spt_to_atlas = load_channel_mapping(mapping_path)
-    atlas_genes = set(load_atlas_gene_names(parquet_path))
+    atlas_genes = set(load_atlas_gene_names(parquet_atlas_path))
     absent = {spt: gene for spt, gene in spt_to_atlas.items() if gene not in atlas_genes}
     if absent:
         logger.warning(
-            "%d mapped channels dropped — atlas gene absent from parquet: %s",
+            '%d mapped channels dropped — atlas gene absent from parquet: %s',
             len(absent), sorted(absent.items()),
         )
         spt_to_atlas = {spt: gene for spt, gene in spt_to_atlas.items() if gene in atlas_genes}
     logger.info(
-        "Atlas feature summary: %d atlas genes in parquet, %d SPT channels mapped",
+        'Atlas feature summary: %d atlas genes in parquet, %d SPT channels mapped',
         len(atlas_genes), len(spt_to_atlas),
     )
 
     # ── Compute training plan up-front ──────────────────────────────────────
     plan: list[dict] = []
     for study_name, channels in study_channels.items():
-        id_in_atlas = [c for c in channels["identity"] if c in spt_to_atlas]
-        fn_in_atlas = [c for c in channels["functional"] if c in spt_to_atlas]
+        id_in_atlas = [c for c in channels['identity'] if c in spt_to_atlas]
+        fn_in_atlas = [c for c in channels['functional'] if c in spt_to_atlas]
         logger.info(
-            "Study '%s': %d dataset channels → %d atlas-matched "
-            "(identity %d/%d, functional %d/%d)",
+            'Study "%s": %d dataset channels → %d atlas-matched '
+            '(identity %d/%d, functional %d/%d)',
             study_name,
-            len(channels["identity"]) + len(channels["functional"]),
+            len(channels['identity']) + len(channels['functional']),
             len(id_in_atlas) + len(fn_in_atlas),
-            len(id_in_atlas), len(channels["identity"]),
-            len(fn_in_atlas), len(channels["functional"]),
+            len(id_in_atlas), len(channels['identity']),
+            len(fn_in_atlas), len(channels['functional']),
         )
         if id_in_atlas and fn_in_atlas:
             plan.append({
-                "study": study_name,
-                "identity": id_in_atlas,
-                "functional": fn_in_atlas,
+                'study': study_name,
+                'identity': id_in_atlas,
+                'functional': fn_in_atlas,
             })
 
-    total_models = sum(len(p["functional"]) for p in plan)
+    total_models = sum(len(p['functional']) for p in plan)
 
     if dry_run:
-        section("DRY RUN — Training plan")
+        section('DRY RUN — Training plan')
         for p in plan:
-            subsection(f"Study: {p['study']}")
+            subsection(f'Study: {p["study"]}')
             logger.info(
-                "  Identity features (%d): %s", len(p["identity"]), p["identity"]
+                '  Identity features (%d): %s', len(p['identity']), p['identity']
             )
-            for fc in p["functional"]:
-                logger.info("  → model: target='%s'  features=%s", fc, p["identity"])
-        print(f"\nTotal: {len(plan)} studies, {total_models} models to train.", flush=True)
+            for fc in p['functional']:
+                logger.info('  → model: target="%s"  features=%s', fc, p['identity'])
+        print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
         return
 
     section(
-        f"Atlas-reference model training — "
-        f"{len(plan)} studies, {total_models} models total"
+        f'Atlas-reference model training — '
+        f'{len(plan)} studies, {total_models} models total'
     )
-    logger.info("Output directory: %s", output_dir.resolve())
+    logger.info('Output directory: %s', output_dir.resolve())
     if max_cells:
-        logger.info("Max atlas cells per study: %s", f"{max_cells:,}")
+        logger.info('Max atlas cells per study: %s', f'{max_cells:,}')
     else:
-        logger.info("Using full atlas (no cell limit)")
-    logger.info("Cross-validation folds: %d", cv_folds)
+        logger.info('Using full atlas (no cell limit)')
+    logger.info('Cross-validation folds: %d', cv_folds)
 
     rng = np.random.default_rng(42)
     run_start = time.monotonic()
@@ -195,23 +190,23 @@ def run(
 
     # Train one model per (study, functional marker).
     for study_idx, p in enumerate(plan, 1):
-        study_name = p["study"]
-        id_in_atlas = p["identity"]
-        fn_in_atlas = p["functional"]
+        study_name = p['study']
+        id_in_atlas = p['identity']
+        fn_in_atlas = p['functional']
 
         section(
-            f"[{study_idx}/{len(plan)}] Study: {study_name}  "
-            f"({len(fn_in_atlas)} models to train)"
+            f'[{study_idx}/{len(plan)}] Study: {study_name}  '
+            f'({len(fn_in_atlas)} models to train)'
         )
-        logger.info("  Identity features : %s", id_in_atlas)
-        logger.info("  Functional targets: %s", fn_in_atlas)
+        logger.info('  Identity features : %s', id_in_atlas)
+        logger.info('  Functional targets: %s', fn_in_atlas)
 
         # Load all needed atlas columns in one shot (identity + all functional targets)
         needed_spt = id_in_atlas + [f for f in fn_in_atlas if f not in id_in_atlas]
         needed_atlas = [spt_to_atlas[c] for c in needed_spt]
 
         X_all, _ = load_atlas_subset(
-            parquet_path, needed_atlas, needed_spt,
+            parquet_atlas_path, needed_atlas, needed_spt,
             max_cells=max_cells, rng=rng,
         )
 
@@ -223,22 +218,22 @@ def run(
         valid_mask = row_sums > 1e-8
         n_zero_sum = int((~valid_mask).sum())
         if n_zero_sum:
-            logger.info("  Removed %d cells with zero identity-channel sum", n_zero_sum)
+            logger.info('  Removed %d cells with zero identity-channel sum', n_zero_sum)
         X_identity_norm = X_identity[valid_mask] / row_sums[valid_mask, np.newaxis]
         X_all_filtered = X_all[valid_mask]
         S_valid = row_sums[valid_mask]
         logger.info(
-            "  Normalized: %s cells retained  (%.2f%% of loaded)",
-            f"{X_identity_norm.shape[0]:,}",
+            '  Normalized: %s cells retained  (%.2f%% of loaded)',
+            f'{X_identity_norm.shape[0]:,}',
             100.0 * X_identity_norm.shape[0] / X_all.shape[0],
         )
 
         for target_idx_local, target_channel in enumerate(fn_in_atlas, 1):
             model_counter += 1
             subsection(
-                f"Model [{model_counter}/{total_models}]  "
-                f"study='{study_name}'  target='{target_channel}'  "
-                f"({target_idx_local}/{len(fn_in_atlas)} in study)"
+                f'Model [{model_counter}/{total_models}]  '
+                f'study="{study_name}"  target="{target_channel}"  '
+                f'({target_idx_local}/{len(fn_in_atlas)} in study)'
             )
 
             target_col = col_idx[target_channel]
@@ -249,18 +244,18 @@ def run(
                 logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
                 continue
 
-            logger.info("  Features : %d identity markers, %s cells (after S>0 filter)",
-                        X_identity_norm.shape[1], f"{X_identity_norm.shape[0]:,}")
-            logger.info("  Target   : '%s' (norm; range %.4f – %.4f, mean %.4f)",
+            logger.info('  Features : %d identity markers, %s cells (after S>0 filter)',
+                        X_identity_norm.shape[1], f'{X_identity_norm.shape[0]:,}')
+            logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)',
                         target_channel, float(y_norm.min()), float(y_norm.max()), float(y_norm.mean()))
 
             X_train, X_test, y_train, y_test = train_test_split(
                 X_identity_norm, y_norm, test_size=0.2, random_state=42
             )
-            logger.info("  Split    : %s train / %s test",
-                        f"{len(X_train):,}", f"{len(X_test):,}")
+            logger.info('  Split    : %s train / %s test',
+                        f'{len(X_train):,}', f'{len(X_test):,}')
 
-            logger.info("  Training %d model candidates with %d-fold CV …",
+            logger.info('  Training %d model candidates with %d-fold CV …',
                         len(build_model_candidates()), cv_folds)
             t_train_start = time.monotonic()
             best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
@@ -274,22 +269,22 @@ def run(
             global_std = float(residuals.std())
             std_method = STD_METHODS[best_name]
             # GaussianProcess only reproduces in double precision; others use float32.
-            double_precision = best_name == "gaussian_process"
-            onnx_input_dtype = "float64" if double_precision else "float32"
+            double_precision = best_name == 'gaussian_process'
+            onnx_input_dtype = 'float64' if double_precision else 'float32'
             train_seconds = time.monotonic() - t_train_start
             train_elapsed = format_elapsed(train_seconds)
             logger.info(
-                "  Result   : model='%s'  test_R²=%.4f  test_MAE=%.4f"
-                "  std_method=%s  global_std=%.4f  [%s]",
+                '  Result   : model="%s"  test_R²=%.4f  test_MAE=%.4f'
+                '  std_method=%s  global_std=%.4f  [%s]',
                 best_name, test_r2, test_mae, std_method, global_std, train_elapsed,
             )
 
             # Sanitize channel name for filesystem
-            safe_target = target_channel.replace("/", "_").replace(" ", "_")
+            safe_target = target_channel.replace('/', '_').replace(' ', '_')
             study_out_dir = output_dir / study_name
-            onnx_path = study_out_dir / f"{safe_target}.onnx"
-            pkl_path = study_out_dir / f"{safe_target}.pkl"
-            meta_path = study_out_dir / f"{safe_target}.meta.json"
+            onnx_path = study_out_dir / f'{safe_target}.onnx'
+            pkl_path = study_out_dir / f'{safe_target}.pkl'
+            meta_path = study_out_dir / f'{safe_target}.meta.json'
 
             export_to_onnx(best_model, X_identity_norm.shape[1], onnx_path,
                            double_precision=double_precision)
@@ -300,9 +295,9 @@ def run(
 
             # Keep the sklearn pickle too: per-cell std is computed in Python, not from ONNX.
             study_out_dir.mkdir(parents=True, exist_ok=True)
-            with open(pkl_path, "wb") as pkl_f:
+            with open(pkl_path, 'wb') as pkl_f:
                 pickle.dump(best_model, pkl_f)
-            logger.info("Pickle saved: %s (%.1f KB)", pkl_path, pkl_path.stat().st_size / 1024)
+            logger.info('Pickle saved: %s (%.1f KB)', pkl_path, pkl_path.stat().st_size / 1024)
 
             write_metadata(
                 meta_path,
@@ -324,32 +319,32 @@ def run(
             )
 
             summary_rows.append({
-                "study": study_name,
-                "target": target_channel,
-                "model": best_name,
-                "std_method": std_method,
-                "cv_R²": cv_r2,
-                "test_R²": test_r2,
-                "test_MAE": test_mae,
-                "onnx_kb": onnx_path.stat().st_size // 1024,
+                'study': study_name,
+                'target': target_channel,
+                'model': best_name,
+                'std_method': std_method,
+                'cv_R²': cv_r2,
+                'test_R²': test_r2,
+                'test_MAE': test_mae,
+                'onnx_kb': onnx_path.stat().st_size // 1024,
             })
 
             if database_config_file is not None:
                 model_records.append({
-                    "study": study_name,
-                    "target_channel": target_channel,
-                    "input_channels": id_in_atlas,
-                    "architecture_type": best_name,
-                    "std_method": std_method,
-                    "onnx_input_dtype": onnx_input_dtype,
-                    "atlas_version": ATLAS_VERSION,
-                    "cv_r2": cv_r2,
-                    "test_r2": test_r2,
-                    "test_mae": test_mae,
-                    "n_train": len(X_train),
-                    "n_test": len(X_test),
-                    "training_time_seconds": train_seconds,
-                    "onnx_bytes": onnx_path.read_bytes(),
+                    'study': study_name,
+                    'target_channel': target_channel,
+                    'input_channels': id_in_atlas,
+                    'architecture_type': best_name,
+                    'std_method': std_method,
+                    'onnx_input_dtype': onnx_input_dtype,
+                    'atlas_version': ATLAS_VERSION,
+                    'cv_r2': cv_r2,
+                    'test_r2': test_r2,
+                    'test_mae': test_mae,
+                    'n_train': len(X_train),
+                    'n_test': len(X_test),
+                    'training_time_seconds': train_seconds,
+                    'onnx_bytes': onnx_path.read_bytes(),
                 })
 
     if model_records:
@@ -357,18 +352,19 @@ def run(
 
     # ── Final summary ────────────────────────────────────────────────────────
     total_elapsed = format_elapsed(time.monotonic() - run_start)
-    section(f"Training complete — {model_counter} models in {total_elapsed}")
+    section(f'Training complete — {model_counter} models in {total_elapsed}')
     if summary_rows:
-        header = (f"  {'Study':<24}  {'Target':<16}  {'Model':<24}  {'Std method':<22}"
-                  f"  {'cv_R²':>8}  {'test_R²':>8}  {'test_MAE':>10}  {'KB':>6}")
+        header = (f'  {"Study":<24}  {"Target":<16}  {"Model":<24}  {"Std method":<22}'
+                  f'  {"cv_R²":>8}  {"test_R²":>8}  {"test_MAE":>10}  {"KB":>6}')
         print(header, flush=True)
-        print("  " + "─" * (_SUMMARY_WIDTH - 2), flush=True)
+        print('  ' + '─' * (_SUMMARY_WIDTH - 2), flush=True)
         for row in summary_rows:
             print(
-                f"  {row['study']:<24}  {row['target']:<16}  {row['model']:<24}"
-                f"  {row['std_method']:<22}"
-                f"  {row['cv_R²']:>8.4f}  {row['test_R²']:>8.4f}"
-                f"  {row['test_MAE']:>10.4f}  {row['onnx_kb']:>6}",
+                f'  {row["study"]:<24}  {row["target"]:<16}  {row["model"]:<24}'
+                f'  {row["std_method"]:<22}'
+                f'  {row["cv_R²"]:>8.4f}  {row["test_R²"]:>8.4f}'
+                f'  {row["test_MAE"]:>10.4f}  {row["onnx_kb"]:>6}',
                 flush=True,
             )
-    print(f"\nModels saved to: {output_dir.resolve()}", flush=True)
+    print(f'\nModels saved to: {output_dir.resolve()}', flush=True)
+

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -292,6 +292,8 @@ def _train_models_for_study(
     study_name = scenario.study_handle
     id_in_atlas = list(c.atlas_specific for c in scenario.channels.identity)
     fn_in_atlas = list(c.atlas_specific for c in scenario.channels.functional)
+    final_channel_names = list(c.study_specific for c in scenario.channels.identity)
+    final_target_channel_names = list(c.study_specific for c in scenario.channels.functional)
 
     section(
         f'[{plan_step}/{total_studies}] Study: {study_name}  '
@@ -303,6 +305,7 @@ def _train_models_for_study(
     if len(set(id_in_atlas).intersection(fn_in_atlas)) > 0:
         raise ValueError(f'Functional markers overlap with identity markers: {fn_in_atlas}; {id_in_atlas}')
     atlas_channels_for_training = id_in_atlas + fn_in_atlas
+    smprofiler_channels = final_channel_names + final_target_channel_names
 
     X_unfiltered_unscaled = load_atlas_subset(
         options.parquet_atlas_path,
@@ -311,7 +314,6 @@ def _train_models_for_study(
         rng=random_number_generator,
     )
     X_identity_unscaled = X_unfiltered_unscaled[:, [i for i, name in enumerate(atlas_channels_for_training) if name in id_in_atlas]]
-
 
     row_sums_all = X_identity_unscaled.sum(axis=1)
     valid_mask = row_sums_all > 1e-8
@@ -328,16 +330,16 @@ def _train_models_for_study(
     )
 
     model_counter = 0
-    def _is_functional_column(index_channel: tuple[int, str]) -> bool:
-        _, atlas_channel = index_channel
+    def _is_functional_column(index_channel: tuple[int, tuple[str, str]]) -> bool:
+        _, (atlas_channel, _) = index_channel
         return atlas_channel in fn_in_atlas
-    targets = tuple(filter(_is_functional_column, enumerate(atlas_channels_for_training)))
-    for target_index_local, (column_index, atlas_channel) in enumerate(targets, 1):
+    targets = tuple(filter(_is_functional_column, enumerate(zip(atlas_channels_for_training, smprofiler_channels))))
+    for counter, (column_index, (atlas_channel, smprofiler_channel)) in enumerate(targets, 1):
         model_counter += 1
         subsection(
             f'Model [{model_counter + number_trained}/{total_models}]  '
             f'study="{study_name}"  target="{atlas_channel}"  '
-            f'({target_index_local}/{len(fn_in_atlas)} in study)'
+            f'({counter}/{len(targets)} in study)'
         )
 
         target_channel = atlas_channel
@@ -356,11 +358,8 @@ def _train_models_for_study(
         X_train, X_test, y_train, y_test = train_test_split(
             X_identity, y, test_size=0.2, random_state=42
         )
-        logger.info('  Split    : %s train / %s test',
-                    f'{len(X_train):,}', f'{len(X_test):,}')
-
-        logger.info('  Training %d model candidates with %d-fold CV …',
-                    len(build_model_candidates()), options.cv_folds)
+        logger.info('  Split    : %s train / %s test', '{len(X_train):,}', f'{len(X_test):,}')
+        logger.info('  Training %d model candidates with %d-fold CV …', len(build_model_candidates()), options.cv_folds)
         t_train_start = time.monotonic()
         best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
             X_train, y_train, cv_folds=options.cv_folds
@@ -386,15 +385,12 @@ def _train_models_for_study(
         safe_target = target_channel.replace('/', '_').replace(' ', '_')
         study_out_dir = options.output_dir / study_name
         onnx_path = study_out_dir / f'{safe_target}.onnx'
-        pkl_path = study_out_dir / f'{safe_target}.pkl'
         meta_path = study_out_dir / f'{safe_target}.meta.json'
 
-        export_to_onnx(best_model, X_identity.shape[1], onnx_path,
-                       double_precision=double_precision)
+        export_to_onnx(best_model, X_identity.shape[1], onnx_path, double_precision=double_precision)
 
         n_validate = min(500, X_test.shape[0])
-        validate_onnx(onnx_path, best_model, X_test[:n_validate],
-                      double_precision=double_precision)
+        validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
 
         # Keep the sklearn pickle too: per-cell std is computed in Python, not from ONNX.
         study_out_dir.mkdir(parents=True, exist_ok=True)

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -118,7 +118,7 @@ def _execute_plan(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOpti
     run_start = time.monotonic()
     model_counter = 0
     summary_rows: list[dict] = []
-    model_records: list[dict] = []  # collected for optional database storage
+    model_records: list[dict] = []
     total_models = sum(len(p.channels.functional) for p in plan)
     for study_index, scenario in enumerate(plan, 1):
         number_new_models = _train_models_for_study(
@@ -412,7 +412,7 @@ def _train_model_one_marker(
 
     export_to_onnx(best_model, X_identity.shape[1], onnx_path, double_precision=double_precision)
 
-    n_validate = min(500, X_test.shape[0])
+    n_validate = min(10, X_test.shape[0])
     validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
 
     write_metadata_to_file(

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -117,11 +117,13 @@ def _execute_plan(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOpti
     random_number_generator = default_rng(42)
     run_start = time.monotonic()
     model_counter = 0
+    number_validated = 0
+    number_validated_std = 0
     summary_rows: list[dict] = []
     model_records: list[dict] = []
     total_models = sum(len(p.channels.functional) for p in plan)
     for study_index, scenario in enumerate(plan, 1):
-        number_new_models = _train_models_for_study(
+        number_new_models, validated, validated_std = _train_models_for_study(
             scenario,
             options,
             total_models,
@@ -133,9 +135,11 @@ def _execute_plan(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOpti
             model_counter,
         )
         model_counter += number_new_models
+        number_validated += validated
+        number_validated_std += validated_std
 
     _store_models_in_db(options.database_config_file, model_records)
-    _report_execution_summary(options, run_start, model_counter, summary_rows)
+    _report_execution_summary(options, run_start, model_counter, number_validated, number_validated_std, summary_rows)
 
 def _report_plan_options(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOptions) -> None:
     total_models = sum(len(p.channels.functional) for p in plan)
@@ -150,9 +154,11 @@ def _report_plan_options(plan: tuple[TrainingScenarioStudy, ...], options: Train
         logger.info('Using full atlas (no cell limit)')
     logger.info('Cross-validation folds: %d', options.cv_folds)
 
-def _report_execution_summary(options: TrainingOptions, run_start, number_models: int, summary_rows: list[dict]):
+def _report_execution_summary(options: TrainingOptions, run_start, number_models: int, number_validated: int, number_validated_std: int, summary_rows: list[dict]):
     total_elapsed = format_elapsed(time.monotonic() - run_start)
     section(f'Training complete — {number_models} models in {total_elapsed}')
+    print(f'Number of ONNX models validated against sklearn original, prediction: {number_validated}')
+    print(f'Number of ONNX models validated against sklearn original, standard deviation prediction: {number_validated_std}')
     if summary_rows:
         header = (f'  {"Study":<24}  {"Target":<16}  {"Model":<24}  {"Std method":<22}'
                   f'  {"cv_R²":>8}  {"test_R²":>8}  {"test_MAE":>10}  {"KB":>6}')
@@ -289,7 +295,7 @@ def _train_models_for_study(
     model_records: list[dict],
     plan_step: int,
     number_trained: int,
-) -> int:
+) -> tuple[int, int, int]:
     study_name = scenario.study_handle
     id_in_atlas = list(c.atlas_specific for c in scenario.channels.identity)
     fn_in_atlas = list(c.atlas_specific for c in scenario.channels.functional)
@@ -335,6 +341,8 @@ def _train_models_for_study(
         _, (atlas_channel, _) = index_channel
         return atlas_channel in fn_in_atlas
     targets = tuple(filter(_is_functional_column, enumerate(zip(atlas_channels_for_training, smprofiler_channels))))
+    ordinary_concordances = 0
+    std_concordances = 0
     for counter, (column_index, (atlas_channel, smprofiler_channel)) in enumerate(targets, 1):
         model_counter += 1
         subsection(
@@ -342,7 +350,7 @@ def _train_models_for_study(
             f'study="{study_name}"  target="{atlas_channel}"  '
             f'({counter}/{len(targets)} in study)'
         )
-        _train_model_one_marker(
+        ordinary, std = _train_model_one_marker(
             column_index,
             smprofiler_channel,
             final_channel_names,
@@ -354,7 +362,9 @@ def _train_models_for_study(
             summary_rows,
             model_records,
         )
-    return model_counter
+        ordinary_concordances += 1 if ordinary else 0
+        std_concordances += 1 if std else 0
+    return model_counter, ordinary_concordances, std_concordances
 
 def _train_model_one_marker(
     column_index: int,
@@ -367,14 +377,14 @@ def _train_model_one_marker(
     scenario: TrainingScenarioStudy,
     summary_rows: list[dict],
     model_records: list[dict],
-) -> None:
+) -> tuple[bool, bool]:
     target_channel = smprofiler_channel
     target_col = column_index
     y = X_unscaled[:, target_col] / sums
 
     if y.std() < 1e-6:
         logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
-        return
+        return False, False
 
     logger.info('  Features : %d identity markers, %s cells (after S>0 filter)', X_identity.shape[1], f'{X_identity.shape[0]:,}')
     logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)', target_channel, float(y.min()), float(y.max()), float(y.mean()))
@@ -389,7 +399,7 @@ def _train_model_one_marker(
         X_train, y_train, cv_folds=options.cv_folds
     )
 
-    y_pred_mean, y_pred_std = best_model.predict(X_test, return_std=True)
+    y_pred_mean, _ = best_model.predict(X_test, return_std=True)
     test_r2 = float(r2_score(y_test, y_pred_mean))
     test_mae = float(mean_absolute_error(y_test, y_pred_mean))
     residuals = y_test - y_pred_mean
@@ -412,8 +422,8 @@ def _train_model_one_marker(
 
     export_to_onnx(best_model, X_identity.shape[1], onnx_path, double_precision=double_precision)
 
-    n_validate = min(10, X_test.shape[0])
-    validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
+    n_validate = min(100, X_test.shape[0])
+    ordinary, std = validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
 
     write_metadata_to_file(
         meta_path,
@@ -462,4 +472,5 @@ def _train_model_one_marker(
             'training_time_seconds': train_seconds,
             'onnx_bytes': onnx_path.read_bytes(),
         })
+    return ordinary, std
 

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -9,7 +9,7 @@ Orchestrates the end-to-end run:
 
 The command line adapter for ``run`` lives in ``smprofiler.atlas.scripts.train_atlas_models``.
 """
-import pickle
+from typing import cast
 import json
 import time
 from pathlib import Path
@@ -21,6 +21,7 @@ from attrs import define
 from numpy.random import default_rng
 from numpy.random import Generator as RandomNumberGenerator
 from numpy import newaxis as np_newaxis
+from numpy.typing import NDArray
 
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.model_selection import train_test_split
@@ -149,7 +150,7 @@ def _report_plan_options(plan: tuple[TrainingScenarioStudy, ...], options: Train
         logger.info('Using full atlas (no cell limit)')
     logger.info('Cross-validation folds: %d', options.cv_folds)
 
-def _report_execution_summary(options: TrainingOptions, run_start, number_models: int, summary_rows: list):
+def _report_execution_summary(options: TrainingOptions, run_start, number_models: int, summary_rows: list[dict]):
     total_elapsed = format_elapsed(time.monotonic() - run_start)
     section(f'Training complete — {number_models} models in {total_elapsed}')
     if summary_rows:
@@ -341,109 +342,124 @@ def _train_models_for_study(
             f'study="{study_name}"  target="{atlas_channel}"  '
             f'({counter}/{len(targets)} in study)'
         )
-
-        target_channel = atlas_channel
-        target_col = column_index
-        y = X_unscaled[:, target_col] / sums
-
-        if y.std() < 1e-6:
-            logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
-            continue
-
-        logger.info('  Features : %d identity markers, %s cells (after S>0 filter)',
-                    X_identity.shape[1], f'{X_identity.shape[0]:,}')
-        logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)',
-                    target_channel, float(y.min()), float(y.max()), float(y.mean()))
-
-        X_train, X_test, y_train, y_test = train_test_split(
-            X_identity, y, test_size=0.2, random_state=42
+        _train_model_one_marker(
+            column_index,
+            smprofiler_channel,
+            final_channel_names,
+            X_unscaled,
+            sums,
+            X_identity,
+            options,
+            scenario,
+            summary_rows,
+            model_records,
         )
-        logger.info('  Split    : %s train / %s test', '{len(X_train):,}', f'{len(X_test):,}')
-        logger.info('  Training %d model candidates with %d-fold CV …', len(build_model_candidates()), options.cv_folds)
-        t_train_start = time.monotonic()
-        best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
-            X_train, y_train, cv_folds=options.cv_folds
-        )
-
-        y_pred_mean, y_pred_std = best_model.predict(X_test, return_std=True)
-        test_r2 = float(r2_score(y_test, y_pred_mean))
-        test_mae = float(mean_absolute_error(y_test, y_pred_mean))
-        residuals = y_test - y_pred_mean
-        global_std = float(residuals.std())
-        std_method = 'return_std keyword arg in sklearn or "std" output in onnx'
-        double_precision = best_name == 'gaussian_process'
-        onnx_input_dtype = 'float64' if double_precision else 'float32'
-        train_seconds = time.monotonic() - t_train_start
-        train_elapsed = format_elapsed(train_seconds)
-        logger.info(
-            '  Result   : model="%s"  test_R²=%.4f  test_MAE=%.4f'
-            '  std_method=%s  global_std=%.4f  [%s]',
-            best_name, test_r2, test_mae, std_method, global_std, train_elapsed,
-        )
-
-        # Sanitize channel name for filesystem
-        safe_target = target_channel.replace('/', '_').replace(' ', '_')
-        study_out_dir = options.output_dir / study_name
-        onnx_path = study_out_dir / f'{safe_target}.onnx'
-        meta_path = study_out_dir / f'{safe_target}.meta.json'
-
-        export_to_onnx(best_model, X_identity.shape[1], onnx_path, double_precision=double_precision)
-
-        n_validate = min(500, X_test.shape[0])
-        validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
-
-        # Keep the sklearn pickle too: per-cell std is computed in Python, not from ONNX.
-        study_out_dir.mkdir(parents=True, exist_ok=True)
-        with open(pkl_path, 'wb') as pkl_f:
-            pickle.dump(best_model, pkl_f)
-        logger.info('Pickle saved: %s (%.1f KB)', pkl_path, pkl_path.stat().st_size / 1024)
-
-        write_metadata_to_file(
-            meta_path,
-            study=study_name,
-            target_channel=target_channel,
-            input_channels=id_in_atlas,
-            model_type=best_name,
-            cv_r2=cv_r2,
-            cv_r2_std=cv_r2_std,
-            test_r2=test_r2,
-            test_mae=test_mae,
-            n_train=len(X_train),
-            n_test=len(X_test),
-            atlas_version=ATLAS_VERSION,
-            sum_normalized=True,
-            std_method=std_method,
-            global_std=global_std,
-            onnx_input_dtype=onnx_input_dtype,
-        )
-
-        summary_rows.append({
-            'study': study_name,
-            'target': target_channel,
-            'model': best_name,
-            'std_method': std_method,
-            'cv_R²': cv_r2,
-            'test_R²': test_r2,
-            'test_MAE': test_mae,
-            'onnx_kb': onnx_path.stat().st_size // 1024,
-        })
-
-        if options.database_config_file is not None:
-            model_records.append({
-                'study': study_name,
-                'target_channel': target_channel,
-                'input_channels': id_in_atlas,
-                'architecture_type': best_name,
-                'std_method': std_method,
-                'onnx_input_dtype': onnx_input_dtype,
-                'atlas_version': ATLAS_VERSION,
-                'cv_r2': cv_r2,
-                'test_r2': test_r2,
-                'test_mae': test_mae,
-                'n_train': len(X_train),
-                'n_test': len(X_test),
-                'training_time_seconds': train_seconds,
-                'onnx_bytes': onnx_path.read_bytes(),
-            })
     return model_counter
+
+def _train_model_one_marker(
+    column_index: int,
+    smprofiler_channel: str,
+    final_channel_names: list[str],
+    X_unscaled: NDArray,
+    sums: NDArray,
+    X_identity: NDArray,
+    options: TrainingOptions,
+    scenario: TrainingScenarioStudy,
+    summary_rows: list[dict],
+    model_records: list[dict],
+) -> None:
+    target_channel = smprofiler_channel
+    target_col = column_index
+    y = X_unscaled[:, target_col] / sums
+
+    if y.std() < 1e-6:
+        logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
+        return
+
+    logger.info('  Features : %d identity markers, %s cells (after S>0 filter)', X_identity.shape[1], f'{X_identity.shape[0]:,}')
+    logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)', target_channel, float(y.min()), float(y.max()), float(y.mean()))
+
+    X_train, X_test, y_train, y_test = cast(tuple[NDArray, NDArray, NDArray, NDArray], train_test_split(
+        X_identity, y, test_size=0.2, random_state=42
+    ))
+    logger.info('  Split    : %s train / %s test', '{len(X_train):,}', f'{len(X_test):,}')
+    logger.info('  Training %d model candidates with %d-fold CV …', len(build_model_candidates()), options.cv_folds)
+    t_train_start = time.monotonic()
+    best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
+        X_train, y_train, cv_folds=options.cv_folds
+    )
+
+    y_pred_mean, y_pred_std = best_model.predict(X_test, return_std=True)
+    test_r2 = float(r2_score(y_test, y_pred_mean))
+    test_mae = float(mean_absolute_error(y_test, y_pred_mean))
+    residuals = y_test - y_pred_mean
+    global_std = float(residuals.std())
+    std_method = 'return_std keyword arg in sklearn or "std" output in onnx'
+    double_precision = best_name == 'gaussian_process'
+    onnx_input_dtype = 'float64' if double_precision else 'float32'
+    train_seconds = time.monotonic() - t_train_start
+    train_elapsed = format_elapsed(train_seconds)
+    logger.info(
+        '  Result   : model="%s"  test_R²=%.4f  test_MAE=%.4f'
+        '  std_method=%s  global_std=%.4f  [%s]',
+        best_name, test_r2, test_mae, std_method, global_std, train_elapsed,
+    )
+
+    safe_target = target_channel.replace('/', '_').replace(' ', '_')
+    study_out_dir = options.output_dir / scenario.study_handle
+    onnx_path = study_out_dir / f'{safe_target}.onnx'
+    meta_path = study_out_dir / f'{safe_target}.meta.json'
+
+    export_to_onnx(best_model, X_identity.shape[1], onnx_path, double_precision=double_precision)
+
+    n_validate = min(500, X_test.shape[0])
+    validate_onnx(onnx_path, best_model, X_test[:n_validate], double_precision=double_precision)
+
+    write_metadata_to_file(
+        meta_path,
+        study=scenario.study_handle,
+        target_channel=target_channel,
+        input_channels=final_channel_names,
+        model_type=best_name,
+        cv_r2=cv_r2,
+        cv_r2_std=cv_r2_std,
+        test_r2=test_r2,
+        test_mae=test_mae,
+        n_train=len(X_train),
+        n_test=len(X_test),
+        atlas_version=ATLAS_VERSION,
+        sum_normalized=True,
+        std_method=std_method,
+        global_std=global_std,
+        onnx_input_dtype=onnx_input_dtype,
+    )
+
+    summary_rows.append({
+        'study': scenario.study_handle,
+        'target': target_channel,
+        'model': best_name,
+        'std_method': std_method,
+        'cv_R²': cv_r2,
+        'test_R²': test_r2,
+        'test_MAE': test_mae,
+        'onnx_kb': onnx_path.stat().st_size // 1024,
+    })
+
+    if options.database_config_file is not None:
+        model_records.append({
+            'study': scenario.study_handle,
+            'target_channel': smprofiler_channel,
+            'input_channels': final_channel_names,
+            'architecture_type': best_name,
+            'std_method': std_method,
+            'onnx_input_dtype': onnx_input_dtype,
+            'atlas_version': ATLAS_VERSION,
+            'cv_r2': cv_r2,
+            'test_r2': test_r2,
+            'test_mae': test_mae,
+            'n_train': len(X_train),
+            'n_test': len(X_test),
+            'training_time_seconds': train_seconds,
+            'onnx_bytes': onnx_path.read_bytes(),
+        })
 

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -93,6 +93,68 @@ def _is_available(study: str, collection: str | None, base_url: str) -> bool:
     studies = list(entry['handle'] for entry in data)
     return study in studies
 
+def _report_plan(plan: tuple[TrainingScenario, ...]) -> None:
+    section('DRY RUN — Training plan')
+    total_models = sum(len(p.channels.functional) for p in plan)
+    for p in plan:
+        subsection(f'Study: {p.study_handle}')
+        identity = p.channels.identity
+        logger.info(
+            '  Identity features (%d): %s', len(identity), identity
+        )
+        for fc in p.channels.functional:
+            logger.info('  → model: target="%s"  features=%s', fc.study_specific, list(map(lambda c: c.study_specific, identity)))
+    print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
+
+def _check_files_exist(parquet_atlas_path: Path, channel_mapping_path: Path) -> str:
+    if not parquet_atlas_path.exists():
+        raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
+    if not channel_mapping_path.exists():
+        raise FileNotFoundError(f'Channel mapping file not found: {channel_mapping_path}')
+
+def _form_plan_training_scenarios(
+    parquet_atlas_path: Path,
+    channel_mapping_path: Path,
+    annotations_api_url: str,
+    datasets_dir: Path,
+    study: str | None,
+) -> tuple[TrainingScenario, ...]:
+    if not annotations_api_url:
+        raise RuntimeError(
+            'An annotations API URL is required — loading channel annotations from '
+            'a local file is deprecated. Set annotations_api_url.'
+        )
+    try:
+        identity_channels, aliases = load_channel_annotations_from_api(annotations_api_url)
+    except Exception as exc:
+        raise RuntimeError(
+            f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
+        ) from exc
+
+    if study:
+        study_handles = (study,)
+    else:
+        study_handles = tuple(
+            d.name for d in sorted(datasets_dir.iterdir())
+            if d.is_dir() and d.name != 'template'
+        )
+    study_handles, study_names = _retrieve_full_study_names(datasets_dir, study_handles)
+    study_handles, study_names = _filter_by_availability(study_handles, study_names, base_url=annotations_api_url)
+
+    smprofiler_to_atlas = load_channel_mapping(channel_mapping_path)
+    report_parquet_attributes(parquet_atlas_path, smprofiler_to_atlas)
+    study_channels = retrieve_all_study_channels_from_api(
+        study_names, identity_channels, aliases, smprofiler_to_atlas, base_url=annotations_api_url
+    )
+
+    def _form_scenario(args) -> TrainingScenario:
+        return TrainingScenario(*args)
+    def _non_trivial(ts: TrainingScenario) -> bool:
+        return len(ts.channels.identity)*len(ts.channels.functional) > 0
+    plan = tuple(filter(_non_trivial, map(_form_scenario, zip(study_handles, study_names, study_channels))))
+    return plan
+
+
 def run(
     parquet_atlas_path: Path,
     channel_mapping_path: Path,
@@ -130,60 +192,19 @@ def run(
         RuntimeError if annotations cannot be loaded from the API, or if no
             studies with usable channel data are found.
     """
-    if not parquet_atlas_path.exists():
-        raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
-    if not channel_mapping_path.exists():
-        raise FileNotFoundError(f'Channel mapping file not found: {channel_mapping_path}')
-
-    if not annotations_api_url:
-        raise RuntimeError(
-            'An annotations API URL is required — loading channel annotations from '
-            'a local file is deprecated. Set annotations_api_url.'
-        )
-    try:
-        identity_channels, aliases = load_channel_annotations_from_api(annotations_api_url)
-    except Exception as exc:
-        raise RuntimeError(
-            f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
-        ) from exc
-
-    if study:
-        study_handles = (study,)
-    else:
-        study_handles = tuple(
-            d.name for d in sorted(datasets_dir.iterdir())
-            if d.is_dir() and d.name != 'template'
-        )
-    study_handles, study_names = _retrieve_full_study_names(datasets_dir, study_handles)
-    study_handles, study_names = _filter_by_availability(study_handles, study_names, base_url=annotations_api_url)
-
-    smprofiler_to_atlas = load_channel_mapping(channel_mapping_path)
-    report_parquet_attributes(parquet_atlas_path, smprofiler_to_atlas)
-    study_channels = retrieve_all_study_channels_from_api(
-        study_names, identity_channels, aliases, smprofiler_to_atlas, base_url=annotations_api_url
+    _check_files_exist(parquet_atlas_path, channel_mapping_path)
+    plan = _form_plan_training_scenarios(
+        parquet_atlas_path,
+        channel_mapping_path,
+        annotations_api_url,
+        datasets_dir,
+        study,
     )
-
-    def _form_scenario(args) -> TrainingScenario:
-        return TrainingScenario(*args)
-    def _non_trivial(ts: TrainingScenario) -> bool:
-        return len(ts.channels.identity)*len(ts.channels.functional) > 0
-    plan = tuple(filter(_non_trivial, map(_form_scenario, zip(study_handles, study_names, study_channels))))
-
-    total_models = sum(len(p.channels.functional) for p in plan)
-
     if dry_run:
-        section('DRY RUN — Training plan')
-        for p in plan:
-            subsection(f'Study: {p.study_handle}')
-            identity = p.channels.identity
-            logger.info(
-                '  Identity features (%d): %s', len(identity), identity
-            )
-            for fc in p.channels.functional:
-                logger.info('  → model: target="%s"  features=%s', fc.study_specific, identity.study_specific))
-        print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
+        _report_plan(plan)
         return
 
+    total_models = sum(len(p.channels.functional) for p in plan)
     section(
         f'Atlas-reference model training — '
         f'{len(plan)} studies, {total_models} models total'

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -13,18 +13,21 @@ import pickle
 import json
 import time
 from pathlib import Path
-from itertools import chain
 from urllib.request import Request
 from urllib.request import urlopen
 from urllib.parse import quote_plus
 
 from attrs import define
-import numpy as np
+from numpy.random import default_rng
+from numpy.random import Generator as RandomNumberGenerator
+from numpy import newaxis as np_newaxis
+
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.model_selection import train_test_split
 
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 from smprofiler.db.study_tokens import StudyCollectionNaming
+from smprofiler.atlas.cache import StandaloneSQLiteHTTPCache
 from smprofiler.atlas.reporting import format_elapsed, section, subsection
 from smprofiler.atlas.channel_annotations import load_channel_annotations_from_api
 from smprofiler.atlas.study_channels import retrieve_all_study_channels_from_api
@@ -45,115 +48,18 @@ DEFAULT_ANNOTATIONS_API_URL = 'https://smprofiler.io/api'
 _SUMMARY_WIDTH = 70
 
 @define
-class TrainingScenario:
+class TrainingScenarioStudy:
     study_handle: str
     study_name: str
     channels: StudyOrderedChannels
 
-def _store_models_in_db(database_config_file: Path, model_records: list[dict]) -> None:
-    # Imported lazily so the file-only training path carries no database dependency.
-    from smprofiler.db.accessors.atlas_models import store_models_in_db
-    store_models_in_db(database_config_file, model_records) 
-
-def _retrieve_full_study_names(datasets_dir: Path, study_handles: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    _study_handles = []
-    _study_names = []
-    for handle in study_handles:
-        study_json = datasets_dir / handle / 'generated_artifacts' / 'study.json'
-        if not study_json.exists():
-            logger.warning("Dataset metadata not found for: %s", handle)
-            continue
-        _study_handles.append(handle)
-        _study_names.append(StudyCollectionNaming.extract_study_from_file(study_json))
-    return tuple(_study_handles), tuple(_study_names)
-
-def _filter_by_availability(
-    study_handles: tuple[str, ...],
-    study_names: tuple[str, ...],
-    base_url: str,
-) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    handles, names = [], []
-    for h, n in zip(study_handles, study_names):
-        if _is_available(n, StudyCollectionNaming.strip_token(n)[1], base_url):
-            handles.append(h)
-            names.append(n)
-        else:
-            logger.warning('Study data for %s (%s) is not live.', h, n)
-    return tuple(handles), tuple(names)
-
-def _is_available(study: str, collection: str | None, base_url: str) -> bool:
-    base = base_url.rstrip('/')
-    if collection is not None:
-        url = f'{base}/study-names/?collection={quote_plus(collection)}'
-    else:
-        url = f'{base}/study-names/'
-    request = Request(url, headers={'Accept': 'application/json'})
-    with urlopen(request, timeout=30) as response:
-        data = json.load(response)
-    studies = list(entry['handle'] for entry in data)
-    return study in studies
-
-def _report_plan(plan: tuple[TrainingScenario, ...]) -> None:
-    section('DRY RUN — Training plan')
-    total_models = sum(len(p.channels.functional) for p in plan)
-    for p in plan:
-        subsection(f'Study: {p.study_handle}')
-        identity = p.channels.identity
-        logger.info(
-            '  Identity features (%d): %s', len(identity), identity
-        )
-        for fc in p.channels.functional:
-            logger.info('  → model: target="%s"  features=%s', fc.study_specific, list(map(lambda c: c.study_specific, identity)))
-    print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
-
-def _check_files_exist(parquet_atlas_path: Path, channel_mapping_path: Path) -> str:
-    if not parquet_atlas_path.exists():
-        raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
-    if not channel_mapping_path.exists():
-        raise FileNotFoundError(f'Channel mapping file not found: {channel_mapping_path}')
-
-def _form_plan_training_scenarios(
-    parquet_atlas_path: Path,
-    channel_mapping_path: Path,
-    annotations_api_url: str,
-    datasets_dir: Path,
-    study: str | None,
-) -> tuple[TrainingScenario, ...]:
-    if not annotations_api_url:
-        raise RuntimeError(
-            'An annotations API URL is required — loading channel annotations from '
-            'a local file is deprecated. Set annotations_api_url.'
-        )
-    try:
-        identity_channels, aliases = load_channel_annotations_from_api(annotations_api_url)
-    except Exception as exc:
-        raise RuntimeError(
-            f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
-        ) from exc
-
-    if study:
-        study_handles = (study,)
-    else:
-        study_handles = tuple(
-            d.name for d in sorted(datasets_dir.iterdir())
-            if d.is_dir() and d.name != 'template'
-        )
-    study_handles, study_names = _retrieve_full_study_names(datasets_dir, study_handles)
-    study_handles, study_names = _filter_by_availability(study_handles, study_names, base_url=annotations_api_url)
-
-    smprofiler_to_atlas = load_channel_mapping(channel_mapping_path)
-    report_parquet_attributes(parquet_atlas_path, smprofiler_to_atlas)
-    study_channels = retrieve_all_study_channels_from_api(
-        study_names, identity_channels, aliases, smprofiler_to_atlas, base_url=annotations_api_url
-    )
-
-    def _form_scenario(args) -> TrainingScenario:
-        return TrainingScenario(*args)
-    def _non_trivial(ts: TrainingScenario) -> bool:
-        return len(ts.channels.identity)*len(ts.channels.functional) > 0
-    plan = tuple(filter(_non_trivial, map(_form_scenario, zip(study_handles, study_names, study_channels))))
-    return plan
-
+@define
+class TrainingOptions:
+    output_dir: Path
+    max_cells: int | None
+    cv_folds: int
+    database_config_file: Path | None
+    parquet_atlas_path: Path
 
 def run(
     parquet_atlas_path: Path,
@@ -203,190 +109,41 @@ def run(
     if dry_run:
         _report_plan(plan)
         return
+    options = TrainingOptions(output_dir, max_cells, cv_folds, database_config_file, parquet_atlas_path)
+    _execute_plan(plan, options)
 
+def _execute_plan(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOptions) -> None:
+    _report_plan_options(plan, options)
+
+    random_number_generator = default_rng(42)
+    run_start = time.monotonic()
+    model_counter = 0
+    summary_rows: list[dict] = []
+    model_records: list[dict] = []  # collected for optional database storage
+    total_models = sum(len(p.channels.functional) for p in plan)
+    for study_index, scenario in enumerate(plan, 1):
+        number_new_models = _train_models_for_study(scenario, options, total_models, len(plan), random_number_generator, summary_rows, model_records, study_index, model_counter)
+        model_counter += number_new_models
+
+    _store_models_in_db(options.database_config_file, model_records)
+    _report_execution_summary(options, run_start, model_counter, summary_rows)
+
+def _report_plan_options(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOptions) -> None:
     total_models = sum(len(p.channels.functional) for p in plan)
     section(
         f'Atlas-reference model training — '
         f'{len(plan)} studies, {total_models} models total'
     )
-    logger.info('Output directory: %s', output_dir.resolve())
-    if max_cells:
-        logger.info('Max atlas cells per study: %s', f'{max_cells:,}')
+    logger.info('Output directory: %s', options.output_dir.resolve())
+    if options.max_cells:
+        logger.info('Max atlas cells per study: %s', f'{options.max_cells:,}')
     else:
         logger.info('Using full atlas (no cell limit)')
-    logger.info('Cross-validation folds: %d', cv_folds)
+    logger.info('Cross-validation folds: %d', options.cv_folds)
 
-    rng = np.random.default_rng(42)
-    run_start = time.monotonic()
-    model_counter = 0
-    summary_rows: list[dict] = []
-    model_records: list[dict] = []  # collected for optional database storage
-
-    # Train one model per (study, functional marker).
-    for study_idx, p in enumerate(plan, 1):
-        study_name = p['study']
-        id_in_atlas = p['identity']
-        fn_in_atlas = p['functional']
-
-        section(
-            f'[{study_idx}/{len(plan)}] Study: {study_name}  '
-            f'({len(fn_in_atlas)} models to train)'
-        )
-        logger.info('  Identity features : %s', id_in_atlas)
-        logger.info('  Functional targets: %s', fn_in_atlas)
-
-        # Load all needed atlas columns in one shot (identity + all functional targets)
-        needed_spt = id_in_atlas + [f for f in fn_in_atlas if f not in id_in_atlas]
-        needed_atlas = [spt_to_atlas[c] for c in needed_spt]
-
-        X_all, _ = load_atlas_subset(
-            parquet_atlas_path, needed_atlas, needed_spt,
-            max_cells=max_cells, rng=rng,
-        )
-
-        col_idx = {name: i for i, name in enumerate(needed_spt)}
-        X_identity = X_all[:, [col_idx[c] for c in id_in_atlas]]
-
-        # Sum-normalize by identity-channel row sums (removes overall scale effect).
-        row_sums = X_identity.sum(axis=1)
-        valid_mask = row_sums > 1e-8
-        n_zero_sum = int((~valid_mask).sum())
-        if n_zero_sum:
-            logger.info('  Removed %d cells with zero identity-channel sum', n_zero_sum)
-        X_identity_norm = X_identity[valid_mask] / row_sums[valid_mask, np.newaxis]
-        X_all_filtered = X_all[valid_mask]
-        S_valid = row_sums[valid_mask]
-        logger.info(
-            '  Normalized: %s cells retained  (%.2f%% of loaded)',
-            f'{X_identity_norm.shape[0]:,}',
-            100.0 * X_identity_norm.shape[0] / X_all.shape[0],
-        )
-
-        for target_idx_local, target_channel in enumerate(fn_in_atlas, 1):
-            model_counter += 1
-            subsection(
-                f'Model [{model_counter}/{total_models}]  '
-                f'study="{study_name}"  target="{target_channel}"  '
-                f'({target_idx_local}/{len(fn_in_atlas)} in study)'
-            )
-
-            target_col = col_idx[target_channel]
-            y_norm = X_all_filtered[:, target_col] / S_valid
-
-            # Skip if target has zero variance after normalization (uninformative)
-            if y_norm.std() < 1e-6:
-                logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
-                continue
-
-            logger.info('  Features : %d identity markers, %s cells (after S>0 filter)',
-                        X_identity_norm.shape[1], f'{X_identity_norm.shape[0]:,}')
-            logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)',
-                        target_channel, float(y_norm.min()), float(y_norm.max()), float(y_norm.mean()))
-
-            X_train, X_test, y_train, y_test = train_test_split(
-                X_identity_norm, y_norm, test_size=0.2, random_state=42
-            )
-            logger.info('  Split    : %s train / %s test',
-                        f'{len(X_train):,}', f'{len(X_test):,}')
-
-            logger.info('  Training %d model candidates with %d-fold CV …',
-                        len(build_model_candidates()), cv_folds)
-            t_train_start = time.monotonic()
-            best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
-                X_train, y_train, cv_folds=cv_folds
-            )
-
-            y_pred_mean, y_pred_std = predict_with_std(best_model, best_name, X_test)
-            test_r2 = float(r2_score(y_test, y_pred_mean))
-            test_mae = float(mean_absolute_error(y_test, y_pred_mean))
-            residuals = y_test - y_pred_mean
-            global_std = float(residuals.std())
-            std_method = STD_METHODS[best_name]
-            # GaussianProcess only reproduces in double precision; others use float32.
-            double_precision = best_name == 'gaussian_process'
-            onnx_input_dtype = 'float64' if double_precision else 'float32'
-            train_seconds = time.monotonic() - t_train_start
-            train_elapsed = format_elapsed(train_seconds)
-            logger.info(
-                '  Result   : model="%s"  test_R²=%.4f  test_MAE=%.4f'
-                '  std_method=%s  global_std=%.4f  [%s]',
-                best_name, test_r2, test_mae, std_method, global_std, train_elapsed,
-            )
-
-            # Sanitize channel name for filesystem
-            safe_target = target_channel.replace('/', '_').replace(' ', '_')
-            study_out_dir = output_dir / study_name
-            onnx_path = study_out_dir / f'{safe_target}.onnx'
-            pkl_path = study_out_dir / f'{safe_target}.pkl'
-            meta_path = study_out_dir / f'{safe_target}.meta.json'
-
-            export_to_onnx(best_model, X_identity_norm.shape[1], onnx_path,
-                           double_precision=double_precision)
-
-            n_validate = min(500, X_test.shape[0])
-            validate_onnx(onnx_path, best_model, X_test[:n_validate],
-                          double_precision=double_precision)
-
-            # Keep the sklearn pickle too: per-cell std is computed in Python, not from ONNX.
-            study_out_dir.mkdir(parents=True, exist_ok=True)
-            with open(pkl_path, 'wb') as pkl_f:
-                pickle.dump(best_model, pkl_f)
-            logger.info('Pickle saved: %s (%.1f KB)', pkl_path, pkl_path.stat().st_size / 1024)
-
-            write_metadata(
-                meta_path,
-                study=study_name,
-                target_channel=target_channel,
-                input_channels=id_in_atlas,
-                model_type=best_name,
-                cv_r2=cv_r2,
-                cv_r2_std=cv_r2_std,
-                test_r2=test_r2,
-                test_mae=test_mae,
-                n_train=len(X_train),
-                n_test=len(X_test),
-                atlas_version=ATLAS_VERSION,
-                sum_normalized=True,
-                std_method=std_method,
-                global_std=global_std,
-                onnx_input_dtype=onnx_input_dtype,
-            )
-
-            summary_rows.append({
-                'study': study_name,
-                'target': target_channel,
-                'model': best_name,
-                'std_method': std_method,
-                'cv_R²': cv_r2,
-                'test_R²': test_r2,
-                'test_MAE': test_mae,
-                'onnx_kb': onnx_path.stat().st_size // 1024,
-            })
-
-            if database_config_file is not None:
-                model_records.append({
-                    'study': study_name,
-                    'target_channel': target_channel,
-                    'input_channels': id_in_atlas,
-                    'architecture_type': best_name,
-                    'std_method': std_method,
-                    'onnx_input_dtype': onnx_input_dtype,
-                    'atlas_version': ATLAS_VERSION,
-                    'cv_r2': cv_r2,
-                    'test_r2': test_r2,
-                    'test_mae': test_mae,
-                    'n_train': len(X_train),
-                    'n_test': len(X_test),
-                    'training_time_seconds': train_seconds,
-                    'onnx_bytes': onnx_path.read_bytes(),
-                })
-
-    if model_records:
-        _store_models_in_db(database_config_file, model_records)
-
-    # ── Final summary ────────────────────────────────────────────────────────
+def _report_execution_summary(options: TrainingOptions, run_start, number_models: int, summary_rows: list):
     total_elapsed = format_elapsed(time.monotonic() - run_start)
-    section(f'Training complete — {model_counter} models in {total_elapsed}')
+    section(f'Training complete — {number_models} models in {total_elapsed}')
     if summary_rows:
         header = (f'  {"Study":<24}  {"Target":<16}  {"Model":<24}  {"Std method":<22}'
                   f'  {"cv_R²":>8}  {"test_R²":>8}  {"test_MAE":>10}  {"KB":>6}')
@@ -400,6 +157,304 @@ def run(
                 f'  {row["test_MAE"]:>10.4f}  {row["onnx_kb"]:>6}',
                 flush=True,
             )
-    print(f'\nModels saved to: {output_dir.resolve()}', flush=True)
+    print(f'\nModels saved to: {options.output_dir.resolve()}', flush=True)
 
+def _store_models_in_db(database_config_file: Path | None, model_records: list[dict] | None) -> None:
+    if database_config_file is None or model_records is None or len(model_records) == 0:
+        logger.info('Not storing models in database.')
+        return
+    # Imported lazily so the file-only training path carries no database dependency.
+    from smprofiler.db.accessors.atlas_models import store_models_in_db
+    store_models_in_db(database_config_file, model_records) 
+
+def _retrieve_full_study_names(datasets_dir: Path, study_handles: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    _study_handles = []
+    _study_names = []
+    for handle in study_handles:
+        study_json = datasets_dir / handle / 'generated_artifacts' / 'study.json'
+        if not study_json.exists():
+            logger.warning("Dataset metadata not found for: %s", handle)
+            continue
+        _study_handles.append(handle)
+        _study_names.append(StudyCollectionNaming.extract_study_from_file(study_json))
+    return tuple(_study_handles), tuple(_study_names)
+
+def _filter_by_availability(
+    study_handles: tuple[str, ...],
+    study_names: tuple[str, ...],
+    base_url: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    handles, names = [], []
+    for h, n in zip(study_handles, study_names):
+        if _is_available(n, StudyCollectionNaming.strip_token(n)[1], base_url):
+            handles.append(h)
+            names.append(n)
+        else:
+            logger.warning('Study data for %s (%s) is not live.', h, n)
+    return tuple(handles), tuple(names)
+
+def _is_available(study: str, collection: str | None, base_url: str) -> bool:
+    base = base_url.rstrip('/')
+    if collection is not None:
+        url = f'{base}/study-names/?collection={quote_plus(collection)}'
+    else:
+        url = f'{base}/study-names/'
+    response_body = StandaloneSQLiteHTTPCache.retrieve_response(url) 
+    if response_body is None:
+        request = Request(url, headers={'Accept': 'application/json'})
+        with urlopen(request, timeout=30) as response:
+            response_body = response.read()
+            StandaloneSQLiteHTTPCache.cache_response(url, response_body)
+    data = json.loads(response_body.decode())
+    studies = list(entry['handle'] for entry in data)
+    return study in studies
+
+def _report_plan(plan: tuple[TrainingScenarioStudy, ...]) -> None:
+    section('DRY RUN — Training plan')
+    total_models = sum(len(p.channels.functional) for p in plan)
+    for p in plan:
+        subsection(f'Study: {p.study_handle}')
+        identity = p.channels.identity
+        logger.info(
+            '  Identity features (%d): %s', len(identity), identity
+        )
+        for fc in p.channels.functional:
+            logger.info('  → model: target="%s"  features=%s', fc.study_specific, list(map(lambda c: c.study_specific, identity)))
+    print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
+
+def _check_files_exist(parquet_atlas_path: Path, channel_mapping_path: Path) -> str:
+    if not parquet_atlas_path.exists():
+        raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
+    if not channel_mapping_path.exists():
+        raise FileNotFoundError(f'Channel mapping file not found: {channel_mapping_path}')
+
+def _form_plan_training_scenarios(
+    parquet_atlas_path: Path,
+    channel_mapping_path: Path,
+    annotations_api_url: str,
+    datasets_dir: Path,
+    study: str | None,
+) -> tuple[TrainingScenarioStudy, ...]:
+    if not annotations_api_url:
+        raise RuntimeError(
+            'An annotations API URL is required — loading channel annotations from '
+            'a local file is deprecated. Set annotations_api_url.'
+        )
+    try:
+        identity_channels, aliases = load_channel_annotations_from_api(annotations_api_url)
+    except Exception as exc:
+        raise RuntimeError(
+            f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
+        ) from exc
+
+    if study:
+        study_handles = (study,)
+    else:
+        study_handles = tuple(
+            d.name for d in sorted(datasets_dir.iterdir())
+            if d.is_dir() and d.name != 'template'
+        )
+    study_handles, study_names = _retrieve_full_study_names(datasets_dir, study_handles)
+    study_handles, study_names = _filter_by_availability(study_handles, study_names, base_url=annotations_api_url)
+
+    smprofiler_to_atlas = load_channel_mapping(channel_mapping_path)
+    report_parquet_attributes(parquet_atlas_path, smprofiler_to_atlas)
+    study_channels = retrieve_all_study_channels_from_api(
+        study_names, identity_channels, aliases, smprofiler_to_atlas, base_url=annotations_api_url
+    )
+
+    def _form_scenario(args) -> TrainingScenarioStudy:
+        return TrainingScenarioStudy(*args)
+    def _non_trivial(ts: TrainingScenarioStudy) -> bool:
+        return len(ts.channels.identity)*len(ts.channels.functional) > 0
+    plan = tuple(filter(_non_trivial, map(_form_scenario, zip(study_handles, study_names, study_channels))))
+    return plan
+
+def _train_models_for_study(
+    scenario: TrainingScenarioStudy,
+    options: TrainingOptions, 
+    total_models: int,
+    total_studies: int,
+    random_number_generator: RandomNumberGenerator,
+    summary_rows: list[dict],
+    model_records: list[dict],
+    plan_step: int,
+    number_trained: int,
+) -> int:
+    study_name = scenario.study_handle
+    id_in_atlas = list(c.atlas_specific for c in scenario.channels.identity)
+    fn_in_atlas = list(c.atlas_specific for c in scenario.channels.functional)
+
+    section(
+        f'[{plan_step}/{total_studies}] Study: {study_name}  '
+        f'({len(fn_in_atlas)} models to train)'
+    )
+    logger.info('  Identity features : %s', id_in_atlas)
+    logger.info('  Functional targets: %s', fn_in_atlas)
+
+    # Load all needed atlas columns in one shot (identity + all functional targets)
+    #needed_spt = id_in_atlas + [f for f in fn_in_atlas if f not in id_in_atlas]
+    #needed_atlas = [spt_to_atlas[c] for c in needed_spt]
+
+    if len(set(id_in_atlas).intersection(fn_in_atlas)) > 0:
+        raise ValueError(f'Functional markers overlap with identity markers: {fn_in_atlas}; {id_in_atlas}')
+    atlas_channels_for_training = id_in_atlas + fn_in_atlas
+
+    X_all = load_atlas_subset(
+        options.parquet_atlas_path,
+        atlas_channels_for_training,
+        max_cells=options.max_cells,
+        rng=random_number_generator,
+    )
+
+    # the below will pick out only one column fo reach name... if name is duplicated, it's dropped. That's wrong right?
+    #col_idx = {name: i for i, name in enumerate(atlas_channels_for_training)}
+    #X_identity = X_all[:, [col_idx[c] for c in id_in_atlas]]
+
+    #col_idx = {name: i for i, name in enumerate(atlas_channels_for_training)}
+    X_identity = X_all[:, [i for i, name in enumerate(atlas_channels_for_training) if name in id_in_atlas]]
+
+
+    # Sum-normalize by identity-channel row sums (removes overall scale effect).
+    row_sums = X_identity.sum(axis=1)
+    valid_mask = row_sums > 1e-8
+    n_zero_sum = int((~valid_mask).sum())
+    if n_zero_sum:
+        logger.info('  Removed %d cells with zero identity-channel sum', n_zero_sum)
+    X_identity_norm = X_identity[valid_mask] / row_sums[valid_mask, np_newaxis]
+    X_all_filtered = X_all[valid_mask]
+    S_valid = row_sums[valid_mask]
+    logger.info(
+        '  Normalized: %s cells retained  (%.2f%% of loaded)',
+        f'{X_identity_norm.shape[0]:,}',
+        100.0 * X_identity_norm.shape[0] / X_all.shape[0],
+    )
+
+    model_counter = 0
+#    for target_idx_local, target_channel in enumerate(fn_in_atlas, 1):
+    def _is_functional_column(index_channel: tuple[int, str]) -> bool:
+        _, atlas_channel = index_channel
+        return atlas_channel in fn_in_atlas
+    targets = tuple(filter(_is_functional_column, enumerate(atlas_channels_for_training)))
+    for target_index_local, (column_index, atlas_channel) in enumerate(targets, 1):
+        model_counter += 1
+        subsection(
+            f'Model [{model_counter + number_trained}/{total_models}]  '
+            f'study="{study_name}"  target="{atlas_channel}"  '
+            f'({target_index_local}/{len(fn_in_atlas)} in study)'
+        )
+
+        #target_col = col_idx[target_channel]
+        target_channel = atlas_channel
+        target_col = column_index
+        y_norm = X_all_filtered[:, target_col] / S_valid
+
+        # Skip if target has zero variance after normalization (uninformative)
+        if y_norm.std() < 1e-6:
+            logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
+            continue
+
+        logger.info('  Features : %d identity markers, %s cells (after S>0 filter)',
+                    X_identity_norm.shape[1], f'{X_identity_norm.shape[0]:,}')
+        logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)',
+                    target_channel, float(y_norm.min()), float(y_norm.max()), float(y_norm.mean()))
+
+        X_train, X_test, y_train, y_test = train_test_split(
+            X_identity_norm, y_norm, test_size=0.2, random_state=42
+        )
+        logger.info('  Split    : %s train / %s test',
+                    f'{len(X_train):,}', f'{len(X_test):,}')
+
+        logger.info('  Training %d model candidates with %d-fold CV …',
+                    len(build_model_candidates()), options.cv_folds)
+        t_train_start = time.monotonic()
+        best_name, best_model, cv_r2, cv_r2_std = train_and_select_best(
+            X_train, y_train, cv_folds=options.cv_folds
+        )
+
+        y_pred_mean, y_pred_std = predict_with_std(best_model, best_name, X_test)
+        test_r2 = float(r2_score(y_test, y_pred_mean))
+        test_mae = float(mean_absolute_error(y_test, y_pred_mean))
+        residuals = y_test - y_pred_mean
+        global_std = float(residuals.std())
+        std_method = STD_METHODS[best_name]
+        # GaussianProcess only reproduces in double precision; others use float32.
+        double_precision = best_name == 'gaussian_process'
+        onnx_input_dtype = 'float64' if double_precision else 'float32'
+        train_seconds = time.monotonic() - t_train_start
+        train_elapsed = format_elapsed(train_seconds)
+        logger.info(
+            '  Result   : model="%s"  test_R²=%.4f  test_MAE=%.4f'
+            '  std_method=%s  global_std=%.4f  [%s]',
+            best_name, test_r2, test_mae, std_method, global_std, train_elapsed,
+        )
+
+        # Sanitize channel name for filesystem
+        safe_target = target_channel.replace('/', '_').replace(' ', '_')
+        study_out_dir = options.output_dir / study_name
+        onnx_path = study_out_dir / f'{safe_target}.onnx'
+        pkl_path = study_out_dir / f'{safe_target}.pkl'
+        meta_path = study_out_dir / f'{safe_target}.meta.json'
+
+        export_to_onnx(best_model, X_identity_norm.shape[1], onnx_path,
+                       double_precision=double_precision)
+
+        n_validate = min(500, X_test.shape[0])
+        validate_onnx(onnx_path, best_model, X_test[:n_validate],
+                      double_precision=double_precision)
+
+        # Keep the sklearn pickle too: per-cell std is computed in Python, not from ONNX.
+        study_out_dir.mkdir(parents=True, exist_ok=True)
+        with open(pkl_path, 'wb') as pkl_f:
+            pickle.dump(best_model, pkl_f)
+        logger.info('Pickle saved: %s (%.1f KB)', pkl_path, pkl_path.stat().st_size / 1024)
+
+        write_metadata(
+            meta_path,
+            study=study_name,
+            target_channel=target_channel,
+            input_channels=id_in_atlas,
+            model_type=best_name,
+            cv_r2=cv_r2,
+            cv_r2_std=cv_r2_std,
+            test_r2=test_r2,
+            test_mae=test_mae,
+            n_train=len(X_train),
+            n_test=len(X_test),
+            atlas_version=ATLAS_VERSION,
+            sum_normalized=True,
+            std_method=std_method,
+            global_std=global_std,
+            onnx_input_dtype=onnx_input_dtype,
+        )
+
+        summary_rows.append({
+            'study': study_name,
+            'target': target_channel,
+            'model': best_name,
+            'std_method': std_method,
+            'cv_R²': cv_r2,
+            'test_R²': test_r2,
+            'test_MAE': test_mae,
+            'onnx_kb': onnx_path.stat().st_size // 1024,
+        })
+
+        if options.database_config_file is not None:
+            model_records.append({
+                'study': study_name,
+                'target_channel': target_channel,
+                'input_channels': id_in_atlas,
+                'architecture_type': best_name,
+                'std_method': std_method,
+                'onnx_input_dtype': onnx_input_dtype,
+                'atlas_version': ATLAS_VERSION,
+                'cv_r2': cv_r2,
+                'test_r2': test_r2,
+                'test_mae': test_mae,
+                'n_train': len(X_train),
+                'n_test': len(X_test),
+                'training_time_seconds': train_seconds,
+                'onnx_bytes': onnx_path.read_bytes(),
+            })
+    return model_counter
 

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -35,9 +35,8 @@ from smprofiler.atlas.study_channels import StudyOrderedChannels
 from smprofiler.atlas.atlas_data import report_parquet_attributes
 from smprofiler.atlas.atlas_data import load_atlas_subset
 from smprofiler.atlas.atlas_data import load_channel_mapping
-from smprofiler.atlas.models import STD_METHODS
-from smprofiler.atlas.models import build_model_candidates
-from smprofiler.atlas.models import train_and_select_best
+from smprofiler.atlas.model_selection_fitting import build_model_candidates
+from smprofiler.atlas.model_selection_fitting import train_and_select_best
 from smprofiler.atlas.artifacts import export_to_onnx, validate_onnx, write_metadata
 
 logger = colorized_logger(__name__)

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -10,10 +10,15 @@ Orchestrates the end-to-end run:
 The command line adapter for ``run`` lives in ``smprofiler.atlas.scripts.train_atlas_models``.
 """
 import pickle
+import json
 import time
 from pathlib import Path
-from json import read as json_read
+from itertools import chain
+from urllib.request import Request
+from urllib.request import urlopen
+from urllib.parse import quote_plus
 
+from attrs import define
 import numpy as np
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.model_selection import train_test_split
@@ -23,7 +28,8 @@ from smprofiler.db.study_tokens import StudyCollectionNaming
 from smprofiler.atlas.reporting import format_elapsed, section, subsection
 from smprofiler.atlas.channel_annotations import load_channel_annotations_from_api
 from smprofiler.atlas.study_channels import retrieve_all_study_channels_from_api
-from smprofiler.atlas.atlas_data import load_atlas_gene_names
+from smprofiler.atlas.study_channels import StudyOrderedChannels
+from smprofiler.atlas.atlas_data import report_parquet_attributes
 from smprofiler.atlas.atlas_data import load_atlas_subset
 from smprofiler.atlas.atlas_data import load_channel_mapping
 from smprofiler.atlas.models import STD_METHODS
@@ -38,15 +44,58 @@ ATLAS_VERSION = 'allen-human-immune-health-atlas-2025'
 DEFAULT_ANNOTATIONS_API_URL = 'https://smprofiler.io/api'
 _SUMMARY_WIDTH = 70
 
+@define
+class TrainingScenario:
+    study_handle: str
+    study_name: str
+    channels: StudyOrderedChannels
+
 def _store_models_in_db(database_config_file: Path, model_records: list[dict]) -> None:
     # Imported lazily so the file-only training path carries no database dependency.
     from smprofiler.db.accessors.atlas_models import store_models_in_db
     store_models_in_db(database_config_file, model_records) 
 
+def _retrieve_full_study_names(datasets_dir: Path, study_handles: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    _study_handles = []
+    _study_names = []
+    for handle in study_handles:
+        study_json = datasets_dir / handle / 'generated_artifacts' / 'study.json'
+        if not study_json.exists():
+            logger.warning("Dataset metadata not found for: %s", handle)
+            continue
+        _study_handles.append(handle)
+        _study_names.append(StudyCollectionNaming.extract_study_from_file(study_json))
+    return tuple(_study_handles), tuple(_study_names)
+
+def _filter_by_availability(
+    study_handles: tuple[str, ...],
+    study_names: tuple[str, ...],
+    base_url: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    handles, names = [], []
+    for h, n in zip(study_handles, study_names):
+        if _is_available(n, StudyCollectionNaming.strip_token(n)[1], base_url):
+            handles.append(h)
+            names.append(n)
+        else:
+            logger.warning('Study data for %s (%s) is not live.', h, n)
+    return tuple(handles), tuple(names)
+
+def _is_available(study: str, collection: str | None, base_url: str) -> bool:
+    base = base_url.rstrip('/')
+    if collection is not None:
+        url = f'{base}/study-names/?collection={quote_plus(collection)}'
+    else:
+        url = f'{base}/study-names/'
+    request = Request(url, headers={'Accept': 'application/json'})
+    with urlopen(request, timeout=30) as response:
+        data = json.load(response)
+    studies = list(entry['handle'] for entry in data)
+    return study in studies
 
 def run(
     parquet_atlas_path: Path,
-    mapping_path: Path,
+    channel_mapping_path: Path,
     datasets_dir: Path,
     output_dir: Path,
     *,
@@ -63,14 +112,14 @@ def run(
     Args:
         parquet_atlas_path: path to the aggregated atlas expression table
             (file cell_atlas_small.parquet) is cells × atlas genes.
-        mapping_path: path to the manual SMProfiler-channel → atlas-gene mapping
+        channel_mapping_path: path to the manual SMProfiler-channel → atlas-gene mapping
             (smprofiler_channels_to_atlas.tsv).
         datasets_dir: root directory containing per-study dataset folders.
         output_dir: directory for ONNX models, pickles, and metadata.
         annotations_api_url: smprofiler API base URL - the source of channel
             annotations.
         max_cells: max atlas cells to use (random sample); None uses all cells.
-        study: train only for this study; None discovers all studies.
+        study: train only for this study (path fragment handle string); None discovers all studies.
         cv_folds: number of cross-validation folds.
         dry_run: print the training plan without training any models.
         database_config_file: if given, also store each trained model (ONNX model
@@ -83,8 +132,8 @@ def run(
     """
     if not parquet_atlas_path.exists():
         raise FileNotFoundError(f'Atlas parquet file not found: {parquet_atlas_path}')
-    if not mapping_path.exists():
-        raise FileNotFoundError(f'Channel mapping file not found: {mapping_path}')
+    if not channel_mapping_path.exists():
+        raise FileNotFoundError(f'Channel mapping file not found: {channel_mapping_path}')
 
     if not annotations_api_url:
         raise RuntimeError(
@@ -92,82 +141,46 @@ def run(
             'a local file is deprecated. Set annotations_api_url.'
         )
     try:
-        identity_channels, aliases = load_channel_annotations_from_api(
-            annotations_api_url
-        )
+        identity_channels, aliases = load_channel_annotations_from_api(annotations_api_url)
     except Exception as exc:
         raise RuntimeError(
             f'Failed to load channel annotations from API {annotations_api_url}: {exc}'
         ) from exc
 
     if study:
-        study_handles = [study]
+        study_handles = (study,)
     else:
-        study_handles = [
+        study_handles = tuple(
             d.name for d in sorted(datasets_dir.iterdir())
             if d.is_dir() and d.name != 'template'
-        ]
+        )
+    study_handles, study_names = _retrieve_full_study_names(datasets_dir, study_handles)
+    study_handles, study_names = _filter_by_availability(study_handles, study_names, base_url=annotations_api_url)
 
-    _study_names = []
-    for handle in study_handles:
-        study_json = datasets_dir / handle / 'generated_artifacts' / 'study.json'
-        if not study_json.exists():
-            logger.warning("Dataset metadata not found for: %s", handle)
-            continue
-        _study_names.append(StudyCollectionNaming.extract_study_from_file(study_json))
-    study_names = tuple(_study_names)
-
+    smprofiler_to_atlas = load_channel_mapping(channel_mapping_path)
+    report_parquet_attributes(parquet_atlas_path, smprofiler_to_atlas)
     study_channels = retrieve_all_study_channels_from_api(
-        study_names, identity_channels, aliases, base_url=annotations_api_url
+        study_names, identity_channels, aliases, smprofiler_to_atlas, base_url=annotations_api_url
     )
 
-    # Keep only mapped channels whose atlas gene is actually present in the Parquet table.
-    spt_to_atlas = load_channel_mapping(mapping_path)
-    atlas_genes = set(load_atlas_gene_names(parquet_atlas_path))
-    absent = {spt: gene for spt, gene in spt_to_atlas.items() if gene not in atlas_genes}
-    if absent:
-        logger.warning(
-            '%d mapped channels dropped — atlas gene absent from parquet: %s',
-            len(absent), sorted(absent.items()),
-        )
-        spt_to_atlas = {spt: gene for spt, gene in spt_to_atlas.items() if gene in atlas_genes}
-    logger.info(
-        'Atlas feature summary: %d atlas genes in parquet, %d SPT channels mapped',
-        len(atlas_genes), len(spt_to_atlas),
-    )
+    def _form_scenario(args) -> TrainingScenario:
+        return TrainingScenario(*args)
+    def _non_trivial(ts: TrainingScenario) -> bool:
+        return len(ts.channels.identity)*len(ts.channels.functional) > 0
+    plan = tuple(filter(_non_trivial, map(_form_scenario, zip(study_handles, study_names, study_channels))))
 
-    # ── Compute training plan up-front ──────────────────────────────────────
-    plan: list[dict] = []
-    for study_name, channels in study_channels.items():
-        id_in_atlas = [c for c in channels['identity'] if c in spt_to_atlas]
-        fn_in_atlas = [c for c in channels['functional'] if c in spt_to_atlas]
-        logger.info(
-            'Study "%s": %d dataset channels → %d atlas-matched '
-            '(identity %d/%d, functional %d/%d)',
-            study_name,
-            len(channels['identity']) + len(channels['functional']),
-            len(id_in_atlas) + len(fn_in_atlas),
-            len(id_in_atlas), len(channels['identity']),
-            len(fn_in_atlas), len(channels['functional']),
-        )
-        if id_in_atlas and fn_in_atlas:
-            plan.append({
-                'study': study_name,
-                'identity': id_in_atlas,
-                'functional': fn_in_atlas,
-            })
-
-    total_models = sum(len(p['functional']) for p in plan)
+    total_models = sum(len(p.channels.functional) for p in plan)
 
     if dry_run:
         section('DRY RUN — Training plan')
         for p in plan:
-            subsection(f'Study: {p["study"]}')
+            subsection(f'Study: {p.study_handle}')
+            identity = p.channels.identity
             logger.info(
-                '  Identity features (%d): %s', len(p['identity']), p['identity']
+                '  Identity features (%d): %s', len(identity), identity
             )
-            for fc in p['functional']:
-                logger.info('  → model: target="%s"  features=%s', fc, p['identity'])
+            for fc in p.channels.functional:
+                logger.info('  → model: target="%s"  features=%s', fc.study_specific, identity.study_specific))
         print(f'\nTotal: {len(plan)} studies, {total_models} models to train.', flush=True)
         return
 
@@ -367,4 +380,5 @@ def run(
                 flush=True,
             )
     print(f'\nModels saved to: {output_dir.resolve()}', flush=True)
+
 

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -37,7 +37,6 @@ from smprofiler.atlas.atlas_data import load_atlas_subset
 from smprofiler.atlas.atlas_data import load_channel_mapping
 from smprofiler.atlas.models import STD_METHODS
 from smprofiler.atlas.models import build_model_candidates
-from smprofiler.atlas.models import predict_with_std
 from smprofiler.atlas.models import train_and_select_best
 from smprofiler.atlas.artifacts import export_to_onnx, validate_onnx, write_metadata
 
@@ -315,6 +314,7 @@ def _train_models_for_study(
     X_identity = X_all[:, [i for i, name in enumerate(atlas_channels_for_training) if name in id_in_atlas]]
 
 
+    # TODO: below filtering needs to happen before subselection
     # Sum-normalize by identity-channel row sums (removes overall scale effect).
     row_sums = X_identity.sum(axis=1)
     valid_mask = row_sums > 1e-8
@@ -372,7 +372,7 @@ def _train_models_for_study(
             X_train, y_train, cv_folds=options.cv_folds
         )
 
-        y_pred_mean, y_pred_std = predict_with_std(best_model, best_name, X_test)
+        y_pred_mean, y_pred_std = best_model.predict(X_test, return_std=True)
         test_r2 = float(r2_score(y_test, y_pred_mean))
         test_mae = float(mean_absolute_error(y_test, y_pred_mean))
         residuals = y_test - y_pred_mean

--- a/smprofiler/atlas/training.py
+++ b/smprofiler/atlas/training.py
@@ -37,7 +37,7 @@ from smprofiler.atlas.atlas_data import load_atlas_subset
 from smprofiler.atlas.atlas_data import load_channel_mapping
 from smprofiler.atlas.model_selection_fitting import build_model_candidates
 from smprofiler.atlas.model_selection_fitting import train_and_select_best
-from smprofiler.atlas.artifacts import export_to_onnx, validate_onnx, write_metadata
+from smprofiler.atlas.artifacts import export_to_onnx, validate_onnx, write_metadata_to_file
 
 logger = colorized_logger(__name__)
 
@@ -120,7 +120,17 @@ def _execute_plan(plan: tuple[TrainingScenarioStudy, ...], options: TrainingOpti
     model_records: list[dict] = []  # collected for optional database storage
     total_models = sum(len(p.channels.functional) for p in plan)
     for study_index, scenario in enumerate(plan, 1):
-        number_new_models = _train_models_for_study(scenario, options, total_models, len(plan), random_number_generator, summary_rows, model_records, study_index, model_counter)
+        number_new_models = _train_models_for_study(
+            scenario,
+            options,
+            total_models,
+            len(plan),
+            random_number_generator,
+            summary_rows,
+            model_records,
+            study_index,
+            model_counter,
+        )
         model_counter += number_new_models
 
     _store_models_in_db(options.database_config_file, model_records)
@@ -290,47 +300,34 @@ def _train_models_for_study(
     logger.info('  Identity features : %s', id_in_atlas)
     logger.info('  Functional targets: %s', fn_in_atlas)
 
-    # Load all needed atlas columns in one shot (identity + all functional targets)
-    #needed_spt = id_in_atlas + [f for f in fn_in_atlas if f not in id_in_atlas]
-    #needed_atlas = [spt_to_atlas[c] for c in needed_spt]
-
     if len(set(id_in_atlas).intersection(fn_in_atlas)) > 0:
         raise ValueError(f'Functional markers overlap with identity markers: {fn_in_atlas}; {id_in_atlas}')
     atlas_channels_for_training = id_in_atlas + fn_in_atlas
 
-    X_all = load_atlas_subset(
+    X_unfiltered_unscaled = load_atlas_subset(
         options.parquet_atlas_path,
         atlas_channels_for_training,
         max_cells=options.max_cells,
         rng=random_number_generator,
     )
-
-    # the below will pick out only one column fo reach name... if name is duplicated, it's dropped. That's wrong right?
-    #col_idx = {name: i for i, name in enumerate(atlas_channels_for_training)}
-    #X_identity = X_all[:, [col_idx[c] for c in id_in_atlas]]
-
-    #col_idx = {name: i for i, name in enumerate(atlas_channels_for_training)}
-    X_identity = X_all[:, [i for i, name in enumerate(atlas_channels_for_training) if name in id_in_atlas]]
+    X_identity_unscaled = X_unfiltered_unscaled[:, [i for i, name in enumerate(atlas_channels_for_training) if name in id_in_atlas]]
 
 
-    # TODO: below filtering needs to happen before subselection
-    # Sum-normalize by identity-channel row sums (removes overall scale effect).
-    row_sums = X_identity.sum(axis=1)
-    valid_mask = row_sums > 1e-8
+    row_sums_all = X_identity_unscaled.sum(axis=1)
+    valid_mask = row_sums_all > 1e-8
     n_zero_sum = int((~valid_mask).sum())
     if n_zero_sum:
         logger.info('  Removed %d cells with zero identity-channel sum', n_zero_sum)
-    X_identity_norm = X_identity[valid_mask] / row_sums[valid_mask, np_newaxis]
-    X_all_filtered = X_all[valid_mask]
-    S_valid = row_sums[valid_mask]
+    X_identity = X_identity_unscaled[valid_mask] / row_sums_all[valid_mask, np_newaxis]
+    X_unscaled = X_unfiltered_unscaled[valid_mask]
+    sums = row_sums_all[valid_mask]
     logger.info(
         '  Normalized: %s cells retained  (%.2f%% of loaded)',
-        f'{X_identity_norm.shape[0]:,}',
-        100.0 * X_identity_norm.shape[0] / X_all.shape[0],
+        f'{X_identity.shape[0]:,}',
+        100.0 * X_identity.shape[0] / X_unfiltered_unscaled.shape[0],
     )
 
     model_counter = 0
-#    for target_idx_local, target_channel in enumerate(fn_in_atlas, 1):
     def _is_functional_column(index_channel: tuple[int, str]) -> bool:
         _, atlas_channel = index_channel
         return atlas_channel in fn_in_atlas
@@ -343,23 +340,21 @@ def _train_models_for_study(
             f'({target_index_local}/{len(fn_in_atlas)} in study)'
         )
 
-        #target_col = col_idx[target_channel]
         target_channel = atlas_channel
         target_col = column_index
-        y_norm = X_all_filtered[:, target_col] / S_valid
+        y = X_unscaled[:, target_col] / sums
 
-        # Skip if target has zero variance after normalization (uninformative)
-        if y_norm.std() < 1e-6:
+        if y.std() < 1e-6:
             logger.warning("Skipping: target '%s' has near-zero variance", target_channel)
             continue
 
         logger.info('  Features : %d identity markers, %s cells (after S>0 filter)',
-                    X_identity_norm.shape[1], f'{X_identity_norm.shape[0]:,}')
+                    X_identity.shape[1], f'{X_identity.shape[0]:,}')
         logger.info('  Target   : "%s" (norm; range %.4f – %.4f, mean %.4f)',
-                    target_channel, float(y_norm.min()), float(y_norm.max()), float(y_norm.mean()))
+                    target_channel, float(y.min()), float(y.max()), float(y.mean()))
 
         X_train, X_test, y_train, y_test = train_test_split(
-            X_identity_norm, y_norm, test_size=0.2, random_state=42
+            X_identity, y, test_size=0.2, random_state=42
         )
         logger.info('  Split    : %s train / %s test',
                     f'{len(X_train):,}', f'{len(X_test):,}')
@@ -376,8 +371,7 @@ def _train_models_for_study(
         test_mae = float(mean_absolute_error(y_test, y_pred_mean))
         residuals = y_test - y_pred_mean
         global_std = float(residuals.std())
-        std_method = STD_METHODS[best_name]
-        # GaussianProcess only reproduces in double precision; others use float32.
+        std_method = 'return_std keyword arg in sklearn or "std" output in onnx'
         double_precision = best_name == 'gaussian_process'
         onnx_input_dtype = 'float64' if double_precision else 'float32'
         train_seconds = time.monotonic() - t_train_start
@@ -395,7 +389,7 @@ def _train_models_for_study(
         pkl_path = study_out_dir / f'{safe_target}.pkl'
         meta_path = study_out_dir / f'{safe_target}.meta.json'
 
-        export_to_onnx(best_model, X_identity_norm.shape[1], onnx_path,
+        export_to_onnx(best_model, X_identity.shape[1], onnx_path,
                        double_precision=double_precision)
 
         n_validate = min(500, X_test.shape[0])
@@ -408,7 +402,7 @@ def _train_models_for_study(
             pickle.dump(best_model, pkl_f)
         logger.info('Pickle saved: %s (%.1f KB)', pkl_path, pkl_path.stat().st_size / 1024)
 
-        write_metadata(
+        write_metadata_to_file(
             meta_path,
             study=study_name,
             target_channel=target_channel,

--- a/smprofiler/db/accessors/atlas_models.py
+++ b/smprofiler/db/accessors/atlas_models.py
@@ -5,6 +5,8 @@ The table lives in the shared metaschema, so use a metaschema cursor
 versioned snapshot: multiple rows may share a (study, target_channel), ordered by
 ``created``.
 """
+from pathlib import Path
+
 from psycopg import Cursor as PsycopgCursor
 
 from smprofiler.db.database_connection import DBCursor

--- a/smprofiler/db/accessors/atlas_models.py
+++ b/smprofiler/db/accessors/atlas_models.py
@@ -7,6 +7,7 @@ versioned snapshot: multiple rows may share a (study, target_channel), ordered b
 """
 from psycopg import Cursor as PsycopgCursor
 
+from smprofiler.db.database_connection import DBCursor
 from smprofiler.standalone_utilities.log_formats import colorized_logger
 
 logger = colorized_logger(__name__)
@@ -27,6 +28,12 @@ INSERT INTO atlas_model (
 RETURNING id ;
 """
 
+def store_models_in_db(database_config_file: Path, model_records: list[dict]) -> None:
+    """Persist trained models to the ``atlas_model`` table."""
+    logger.info('Storing %d trained model(s) to the "atlas_model" database table…', len(model_records))
+    with DBCursor(database_config_file=str(database_config_file)) as cursor:
+        for record in model_records:
+            store_atlas_model(cursor, **record)
 
 def store_atlas_model(
     cursor: PsycopgCursor,

--- a/smprofiler/db/accessors/atlas_models.py
+++ b/smprofiler/db/accessors/atlas_models.py
@@ -1,13 +1,12 @@
 """Store and retrieve trained atlas-reference models in the ``atlas_model`` table.
 
-The table lives in the shared metaschema, so use a metaschema cursor
-(``DBCursor(database_config_file=...)`` with no ``study``). Each stored row is a
-versioned snapshot: multiple rows may share a (study, target_channel), ordered by
-``created``.
+The table lives in the schema shared across all studies.
 """
+from typing import cast
 from pathlib import Path
 
 from psycopg import Cursor as PsycopgCursor
+from psycopg.rows import TupleRow
 
 from smprofiler.db.database_connection import DBCursor
 from smprofiler.standalone_utilities.log_formats import colorized_logger
@@ -16,9 +15,9 @@ logger = colorized_logger(__name__)
 
 # Metadata columns returned by list_atlas_models (everything except the ONNX bytes).
 _METADATA_COLUMNS = (
-    "id", "study", "target_channel", "input_channels", "architecture_type",
-    "std_method", "onnx_input_dtype", "atlas_version", "cv_r2", "test_r2",
-    "test_mae", "n_train", "n_test", "training_time_seconds", "size_bytes", "created",
+    'id', 'study', 'target_channel', 'input_channels', 'architecture_type',
+    'std_method', 'onnx_input_dtype', 'atlas_version', 'cv_r2', 'test_r2',
+    'test_mae', 'n_train', 'n_test', 'training_time_seconds', 'size_bytes', 'created',
 )
 
 _INSERT = """
@@ -62,9 +61,9 @@ def store_atlas_model(
         onnx_input_dtype, atlas_version, cv_r2, test_r2, test_mae, n_train, n_test,
         training_time_seconds, size_bytes, onnx_bytes,
     ))
-    model_id = cursor.fetchone()[0]
+    model_id = cast(TupleRow, cursor.fetchone())[0]
     logger.info(
-        "Stored atlas model id=%s (study='%s', target='%s', %s, %d bytes)",
+        'Stored atlas model id=%s (study="%s", target="%s", %s, %d bytes)',
         model_id, study, target_channel, architecture_type, size_bytes,
     )
     return model_id
@@ -84,15 +83,15 @@ def list_atlas_models(
     clauses = []
     params: list = []
     if study is not None:
-        clauses.append("study = %s")
+        clauses.append('study = %s')
         params.append(study)
     if target_channel is not None:
-        clauses.append("target_channel = %s")
+        clauses.append('target_channel = %s')
         params.append(target_channel)
-    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-    columns = ", ".join(_METADATA_COLUMNS)
+    where = f'WHERE {' AND '.join(clauses)}' if clauses else ''
+    columns = ', '.join(_METADATA_COLUMNS)
     cursor.execute(
-        f"SELECT {columns} FROM atlas_model {where} ORDER BY created DESC, id DESC ;",
+        f'SELECT {columns} FROM atlas_model {where} ORDER BY created DESC, id DESC ;',
         tuple(params),
     )
     return [dict(zip(_METADATA_COLUMNS, row)) for row in cursor.fetchall()]
@@ -100,6 +99,7 @@ def list_atlas_models(
 
 def get_atlas_model(cursor: PsycopgCursor, model_id: int) -> bytes | None:
     """Return the raw ONNX bytes for a stored model id, or None if absent."""
-    cursor.execute("SELECT onnx_model FROM atlas_model WHERE id = %s ;", (model_id,))
+    cursor.execute('SELECT onnx_model FROM atlas_model WHERE id = %s ;', (model_id,))
     row = cursor.fetchone()
     return bytes(row[0]) if row is not None else None
+

--- a/smprofiler/db/exchange_data_formats/atlas_models.py
+++ b/smprofiler/db/exchange_data_formats/atlas_models.py
@@ -4,16 +4,12 @@ from pydantic import BaseModel
 
 
 class AtlasModelMetadata(BaseModel):
-    """Description of one trained atlas-reference model (without the ONNX bytes).
-
-    Returned by the ``/atlas-models/`` endpoint. Download the model itself from
-    ``/atlas-model/`` using ``id`` (or by ``study`` + ``target_channel``). To run
-    it, feed inputs of dtype ``onnx_input_dtype`` in ``input_channels`` order.
-    """
+    """Description of one trained atlas-reference model (without the ONNX itself). """
     id: int
     study: str | None
     target_channel: str
     input_channels: list[str]
+    reference_dataset: str
     architecture_type: str
     std_method: str
     onnx_input_dtype: str

--- a/smprofiler/db/exchange_data_formats/atlas_models.py
+++ b/smprofiler/db/exchange_data_formats/atlas_models.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 
 class AtlasModelMetadata(BaseModel):
-    """Description of one trained atlas-reference model (without the ONNX itself). """
+    """Description of one trained atlas-reference model (without the ONNX model itself)."""
     id: int
     study: str | None
     target_channel: str
@@ -22,3 +22,4 @@ class AtlasModelMetadata(BaseModel):
     training_time_seconds: float | None
     size_bytes: int | None
     created: datetime
+

--- a/smprofiler/db/study_tokens.py
+++ b/smprofiler/db/study_tokens.py
@@ -1,6 +1,7 @@
 """Deal with naming related to study collection/aggregation tags."""
 import re
 import json
+from pathlib import Path
 
 from smprofiler.db.exchange_data_formats.study import StudyHandle
 
@@ -56,7 +57,7 @@ class StudyCollectionNaming:
         return re.search(fr'^{cls.tag_pattern()}$', tag) is not None
 
     @classmethod
-    def extract_study_from_file(cls, study_json: str) -> str:
+    def extract_study_from_file(cls, study_json: str | Path) -> str:
         with open(study_json, 'rt', encoding='utf-8') as file:
             study = json.loads(file.read())
             study_name = study['Study name']


### PR DESCRIPTION
**Summary of most changes**:
- Factored the training orchestration to consist of smaller code blocks. Added `_form_plan_training_scenarios`, `_execute_plan`, `_train_models_for_study`, and `_train_model_one_marker` for this purpose.
- Systematically included standard deviation of predictive distribution in the ONNX export and ONNX model usage. I tried to deprecate the direct use of the model itself, in favor of exposing only the z-scores output when the user presents both cell identity and functional marker data.
- Deprecated the `StandardScaler` usage because I was worried that we had not completely worked out the implications of using the standard scaling upon the additional channel, the functional marker, at training and inference times. After all we had a good plan for standardizing the overall scale, and I think that should be enough.
- Refactored the channel annotation handling, in order to make clear the differences between the gene names at different levels. See `study_channels.StudyChannel` for the 3 levels.
- Refactored the channel loading to clarify that it is OK to get these from local files, as long as the *format* of these files is identical to the result of the appropriate API call. The purpose of deprecating loading channels from local files was not to prevent being out of sync with the production database, but rather to prevent the atlas training code from reading from an intermediate, non-final format or artifact from the smprofiler-data repository.
- Include study-specific channel loading directly from the API, not from curation artifacts in smprofiler-data. Same reason as above.
- Replaced the feature names in the ONNX model metadata with the names which will be meaningful at inference time, i.e. the corresponding channel names for a specific study. The atlas-specific names were used previously. This includes both the input feature names and the target channel name.
- Deprecated the Python pickled models. The main use case planned at the moment is the JS frontend, so I don't think we will be using the Python-specific sklearn models.

**Additional style stuff**:
- Cut down the documentation strings in a lot of places. Mostly this was to reduce duplication: duplication between documentation notes in 2 different places, as well as duplication between the documentation and what is evident directly from the code. If this has been too aggressive, feel free to restore some of this!
- Expanded a lot of the code to include full names or additional named steps or intermediate variables.
- Renamed SPT => SMProfiler where these older terms still remained.

**Available architectures**.
For now I removed `GaussianProcessRegressor` from the list of candidate architectures, because the O(N^3) limitation makes it impractical for using a meaningful fraction of the 1.8m-rows training dataset. I also removed the two random forest architectures, because it is not clear how to get the ONNX model to produce standard deviation of the predictive distribution. I saw that for such random forests, you had implemented a way to estimate the stddev in the Python sklearn models by reaching into the internal state, but I'm not sure how that would work in terms of the ONNX export. If we can make it work then I'd be happy to bring back the random forest methods.

Unfortunately this means that only the `BayesianRidge` regressor is available, because it is the only one with sufficient runtime performance and stddev estimation. Despite this, I kept the functionality of building a "list of candidates" anyway, even though there is only 1 candidate, because in the future hopefully we can restore some of them.

**Outstanding issues**.
1. I added stddev comparison to the model validation step (which compares each sklearn model with its ONNX export), and it seems that these are always wildly wrong. I'm not sure why. Also the ordinary prediction comparison between the sklearn model and ONNX export is also often poor (about 40% of the 158 models failed this). I'm not sure if this is a bug introduced by the new usage of `SessionOptions` for `convert_sklearn`, or if this latter issue (ordinary prediction difference) is expected for some reason (e.g. a limitation of ONNX).
2. I think we'll need to revisit the markdown doc to update usage.
3. I didn't take a look at the unit tests yet.